### PR TITLE
New features for pregnant plugin

### DIFF
--- a/artwork/humanoid/twoactors-centered.animation
+++ b/artwork/humanoid/twoactors-centered.animation
@@ -164,7 +164,7 @@
 				"properties": {
 					"centered": true,
 					"anchorPart": "actor2-body",
-					"offset": [0,0]
+					"offset": [ 0, 0 ]
 				}
 			},
 			"actor2-emote": {
@@ -301,7 +301,7 @@
 				"properties": {
 					"centered": true,
 					"anchorPart": "actor1-body",
-					"offset": [0,0]
+					"offset": [ 0, 0 ]
 				}
 			},
 			"actor1-emote": {
@@ -438,7 +438,7 @@
 				"properties": {
 					"centered": true,
 					"anchorPart": "actor3-body",
-					"offset": [0,0]
+					"offset": [ 0, 0 ]
 				}
 			},
 			"actor3-emote": {
@@ -575,15 +575,15 @@
 				"properties": {
 					"anchorPart": "actors",
 					"centered": true,
-					"offset": [0,2.5625]
+					"offset": [ 0, 2.5625 ]
 				}
 			},
 			"actors": {
 				"properties": {
 					"anchorPart": "root",
 					"centered": true,
-					"offset": [0,0],
-					"transformationGroups": ["actors"]
+					"offset": [ 0, 0 ],
+					"transformationGroups": [ "actors" ]
 				}
 			},
 			"container": {
@@ -591,83 +591,83 @@
 					"anchorPart": "root",
 					"centered": true,
 					"image": "/artwork/container.png",
-					"offset": [0,6]
+					"offset": [ 0, 6 ]
 				}
 			},
 			"root": {
 				"properties": {
 					"centered": true,
-					"offset": [0,0]
+					"offset": [ 0, 0 ]
 				}
 			},
 			"actor2": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position2": {},
-						"position3": {},
-						"position4": {},
-						"position4_1": {},
-						"position4_2": {},
-						"position5": {},
-						"position6": {},
-						"position7": {},
-						"position8": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position2": { },
+						"position3": { },
+						"position4": { },
+						"position4_1": { },
+						"position4_2": { },
+						"position5": { },
+						"position6": { },
+						"position7": { },
+						"position8": { }
 					}
 				},
 				"properties": {
 					"centered": true,
 					"anchorPart": "actors-inner",
-					"offset": [0,0]
+					"offset": [ 0, 0 ]
 				}
 			},
 			"actor2-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -680,48 +680,48 @@
 			"actor2-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -734,48 +734,48 @@
 			"actor2-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -790,212 +790,212 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [-1.0,0]
+								"offset": [ -1.0, 0 ]
 							}
 						},
 						"idle": {
 							"properties": {
-								"offset": [-1.5,0]
+								"offset": [ -1.5, 0 ]
 							}
 						},
 						"position1": {
 							"properties": {
-								"offset": [0.375,0]
+								"offset": [ 0.375, 0 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.375,0]
+								"offset": [ 0.375, 0 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [0.375,0]
+								"offset": [ 0.375, 0 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.375,0]
+								"offset": [ 0.375, 0 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						}
 					}
@@ -1013,48 +1013,48 @@
 			"actor2-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -1067,48 +1067,48 @@
 			"actor2-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -1121,48 +1121,48 @@
 			"actor2-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -1177,181 +1177,181 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0.5,0.5]
+								"offset": [ 0.5, 0.5 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.5,0.5]
+								"offset": [ 0.5, 0.5 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0.5,0.5]
+								"offset": [ 0.5, 0.5 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.5,0.5]
+								"offset": [ 0.5, 0.5 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [-0.25,0.25]
+								"offset": [ -0.25, 0.25 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.25,0.25]
+								"offset": [ -0.25, 0.25 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [-0.25,0.25]
+								"offset": [ -0.25, 0.25 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.25,0.25]
+								"offset": [ -0.25, 0.25 ]
 							}
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-postclimax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-postclimax": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -1365,159 +1365,159 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [-0.125,-0.125]
+								"offset": [ -0.125, -0.125 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.125,-0.125]
+								"offset": [ -0.125, -0.125 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [-0.125,-0.125]
+								"offset": [ -0.125, -0.125 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.125,-0.125]
+								"offset": [ -0.125, -0.125 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0,-0.125]
+								"offset": [ 0, -0.125 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0,-0.125]
+								"offset": [ 0, -0.125 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0,-0.125]
+								"offset": [ 0, -0.125 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0,-0.125]
+								"offset": [ 0, -0.125 ]
 							}
 						},
 						"position3": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3-postclimax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-postclimax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-postclimax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-postclimax": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -1529,64 +1529,64 @@
 			"actor2-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
 						"position5": {
 							"frameProperties": {
-								"zLevel": [42,42,42,42,42]
+								"zLevel": [ 42, 42, 42, 42, 42 ]
 							}
 						},
 						"position5-climax": {
 							"frameProperties": {
-								"zLevel": [42]
+								"zLevel": [ 42 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
-								"zLevel": [42,42,42,42,42,42,42,42,42,42,42,42,42,42,42]
+								"zLevel": [ 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42 ]
 							}
 						},
 						"position5-reset": {
 							"frameProperties": {
-								"zLevel": [42]
+								"zLevel": [ 42 ]
 							}
 						},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -1610,316 +1610,324 @@
 			"actor2-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": {
+							"properties": {
+								"offset": [ 0.125, -1.25 ]
+							}
+						},
+						"idle": {
+							"properties": {
+								"offset": [ 0.125, -1.25 ]
+							}
+						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-1.25],
-									[0,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25]
+									[ 0.125, -1.25 ],
+									[ 0, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-1.25],
-									[0,-1.25],
-									[0,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25],
-									[-0.125,-1.25]
+									[ 0.125, -1.25 ],
+									[ 0, -1.25 ],
+									[ 0, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.25 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.825],
-									[-0.5,-2],
-									[-0.375,-2],
-									[-0.25,-2],
-									[-0.375,-2]
+									[ -0.625, -1.825 ],
+									[ -0.5, -2 ],
+									[ -0.375, -2 ],
+									[ -0.25, -2 ],
+									[ -0.375, -2 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.625,-1.825]
+								"offset": [ -0.625, -1.825 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.825],
-									[-0.5,-2],
-									[-0.5,-2],
-									[-0.375,-2],
-									[-0.375,-2],
-									[-0.375,-2],
-									[-0.25,-2],
-									[-0.25,-2],
-									[-0.25,-2],
-									[-0.25,-2],
-									[-0.25,-2],
-									[-0.375,-2],
-									[-0.375,-2]
+									[ -0.625, -1.825 ],
+									[ -0.5, -2 ],
+									[ -0.5, -2 ],
+									[ -0.375, -2 ],
+									[ -0.375, -2 ],
+									[ -0.375, -2 ],
+									[ -0.25, -2 ],
+									[ -0.25, -2 ],
+									[ -0.25, -2 ],
+									[ -0.25, -2 ],
+									[ -0.25, -2 ],
+									[ -0.375, -2 ],
+									[ -0.375, -2 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.625,-1.825]
+								"offset": [ -0.625, -1.825 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-1.825],
-									[0.125,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825]
+									[ 0.125, -1.825 ],
+									[ 0.125, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.125,-1.825]
+								"offset": [ 0.125, -1.825 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-1.825],
-									[0.125,-1.825],
-									[0.125,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825],
-									[0,-1.825]
+									[ 0.125, -1.825 ],
+									[ 0.125, -1.825 ],
+									[ 0.125, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ],
+									[ 0, -1.825 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.125,-1.825]
+								"offset": [ 0.125, -1.825 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-1.825],
-									[-0.25,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.625],
-									[-0.375,-1.75]
+									[ -0.125, -1.825 ],
+									[ -0.25, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.125,-1.825]
+								"offset": [ -0.125, -1.825 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-1.825],
-									[-0.25,-1.75],
-									[-0.25,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.75],
-									[-0.375,-1.75]
+									[ -0.125, -1.825 ],
+									[ -0.25, -1.75 ],
+									[ -0.25, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.125,-1.825]
+								"offset": [ -0.125, -1.825 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-1.825],
-									[-0.25,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.625],
-									[-0.375,-1.75]
+									[ -0.125, -1.825 ],
+									[ -0.25, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.75 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.125,-1.825]
+								"offset": [ -0.125, -1.825 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-1.825],
-									[-0.25,-1.75],
-									[-0.25,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.75],
-									[-0.375,-1.75]
+									[ -0.125, -1.825 ],
+									[ -0.25, -1.75 ],
+									[ -0.25, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.125,-1.825]
+								"offset": [ -0.125, -1.825 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-1.825],
-									[-0.25,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.625],
-									[-0.375,-1.75]
+									[ -0.125, -1.825 ],
+									[ -0.25, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.75 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.125,-1.825]
+								"offset": [ -0.125, -1.825 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-1.825],
-									[-0.25,-1.75],
-									[-0.25,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.75],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.75],
-									[-0.375,-1.75]
+									[ -0.125, -1.825 ],
+									[ -0.25, -1.75 ],
+									[ -0.25, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.75 ],
+									[ -0.375, -1.75 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.125,-1.825]
+								"offset": [ -0.125, -1.825 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-1.25],
-									[-0.125,-1.125],
-									[0,-1],
-									[0,-0.825],
-									[0,-1]
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.125 ],
+									[ 0, -1 ],
+									[ 0, -0.825 ],
+									[ 0, -1 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.125,-1.25]
+								"offset": [ -0.125, -1.25 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-1.25],
-									[-0.125,-1.125],
-									[-0.125,-1.125],
-									[0,-1],
-									[0,-1],
-									[0,-1],
-									[0,-0.825],
-									[0,-0.825],
-									[0,-0.825],
-									[0,-0.825],
-									[0,-0.825],
-									[0,-1],
-									[0,-1]
+									[ -0.125, -1.25 ],
+									[ -0.125, -1.125 ],
+									[ -0.125, -1.125 ],
+									[ 0, -1 ],
+									[ 0, -1 ],
+									[ 0, -1 ],
+									[ 0, -0.825 ],
+									[ 0, -0.825 ],
+									[ 0, -0.825 ],
+									[ 0, -0.825 ],
+									[ 0, -0.825 ],
+									[ 0, -1 ],
+									[ 0, -1 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.125,-1.25]
+								"offset": [ -0.125, -1.25 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [-0.125,-2.125]
+								"offset": [ -0.125, -2.125 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.125,-2.125]
+								"offset": [ -0.125, -2.125 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [-0.125,-2.125]
+								"offset": [ -0.125, -2.125 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.125,-2.125]
+								"offset": [ -0.125, -2.125 ]
 							}
 						},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -1930,406 +1938,406 @@
 			"actor2-head": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": { },
+						"idle": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.25],
-									[0.25,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25]
+									[ 0.375, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.375,-0.25]
+								"offset": [ 0.375, -0.25 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25]
+									[ 0.375, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.375,-0.25]
+								"offset": [ 0.375, -0.25 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.625,-1.5],
-									[0.75,-1.5],
-									[0.875,-1.375],
-									[1,-1.375],
-									[0.875,-1.5]
+									[ 0.625, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.875, -1.375 ],
+									[ 1, -1.375 ],
+									[ 0.875, -1.5 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.625,-1.5]
+								"offset": [ 0.625, -1.5 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.625,-1.5],
-									[0.75,-1.5],
-									[0.75,-1.5],
-									[0.875,-1.375],
-									[0.875,-1.375],
-									[0.875,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[0.875,-1.5],
-									[0.875,-1.5]
+									[ 0.625, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.875, -1.375 ],
+									[ 0.875, -1.375 ],
+									[ 0.875, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 0.875, -1.5 ],
+									[ 0.875, -1.5 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.625,-1.5]
+								"offset": [ 0.625, -1.5 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[1.25,-2],
-									[1.25,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2]
+									[ 1.25, -2 ],
+									[ 1.25, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [1.25,-2]
+								"offset": [ 1.25, -2 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[1.25,-2],
-									[1.25,-2],
-									[1.25,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2]
+									[ 1.25, -2 ],
+									[ 1.25, -2 ],
+									[ 1.25, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [1.25,-2]
+								"offset": [ 1.25, -2 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[-0.25,0.125],
-									[-0.25,0.25],
-									[-0.125,0.375],
-									[-0.125,0.5],
-									[-0.125,0.375]
+									[ -0.25, 0.125 ],
+									[ -0.25, 0.25 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.375 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.25,0.125]
+								"offset": [ -0.25, 0.125 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.25,0.125],
-									[-0.25,0.25],
-									[-0.25,0.25],
-									[-0.125,0.375],
-									[-0.125,0.375],
-									[-0.125,0.375],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.375],
-									[-0.125,0.375]
+									[ -0.25, 0.125 ],
+									[ -0.25, 0.25 ],
+									[ -0.25, 0.25 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.25,0.125]
+								"offset": [ -0.25, 0.125 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position7": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25]
+									[ -0.125, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ]
 								]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [-0.125,-0.25]
+								"offset": [ -0.125, -0.25 ]
 							}
 						},
 						"position7-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25],
-									[0,-0.25]
+									[ -0.125, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ],
+									[ 0, -0.25 ]
 								]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [-0.125,-0.25]
+								"offset": [ -0.125, -0.25 ]
 							}
 						},
 						"position8": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position8-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						}
 					}
@@ -2343,48 +2351,48 @@
 			"actor2-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -2397,48 +2405,48 @@
 			"actor2-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -2454,54 +2462,54 @@
 			"actor2-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
 					"anchorPart": "actor2-head",
 					"centered": true,
-					"offset": [0,0],
+					"offset": [ 0, 0 ],
 					"zLevel": 99
 				}
 			},
@@ -2510,373 +2518,373 @@
 					"actors": {
 						"idle": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"idle_laying": {
 							"properties": {
-								"offset": [0.75,-1.875]
+								"offset": [ 0.75, -1.875 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.375,-0.375],
-									[0.25,-0.5],
-									[0.25,-0.625],
-									[0.25,-0.625]
+									[ 0.5, -0.625 ],
+									[ 0.375, -0.375 ],
+									[ 0.25, -0.5 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.5,-0.625]
+								"offset": [ 0.5, -0.625 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.25,-0.5],
-									[0.25,-0.5],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.25, -0.5 ],
+									[ 0.25, -0.5 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.5,-0.625]
+								"offset": [ 0.5, -0.625 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.75],
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[1,-1.875],
-									[0.875,-1.875]
+									[ 0.75, -1.75 ],
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 1, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.75],
-									[0.75,-1.875],
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875]
+									[ 0.75, -1.75 ],
+									[ 0.75, -1.875 ],
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.5,-1.875],
-									[0.625,-1.875]
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.625, -1.875 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.75,-1.875]
+								"offset": [ 0.75, -1.875 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.5,-1.875],
-									[0.5,-1.875],
-									[0.5,-1.875],
-									[0.5,-1.875],
-									[0.5,-1.875],
-									[0.625,-1.875],
-									[0.625,-1.875]
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.625, -1.875 ],
+									[ 0.625, -1.875 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.75,-1.875]
+								"offset": [ 0.75, -1.875 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.75],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.75],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.75],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,-0.125],
-									[0,-0.125],
-									[0,0],
-									[0,0]
+									[ -0.125, 0 ],
+									[ -0.125, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, 0 ],
+									[ 0, 0 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.125,-0.325]
+								"offset": [ -0.125, -0.325 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,-0.125],
-									[-0.125,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,0],
-									[0,0],
-									[0,0],
-									[0,0],
-									[0,0],
-									[0,0],
-									[0,0]
+									[ -0.125, 0 ],
+									[ -0.125, -0.125 ],
+									[ -0.125, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.125,-0.325]
+								"offset": [ -0.125, -0.325 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.375,-1.625]
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.375, -1.625 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.375,-1.625]
+								"offset": [ -0.375, -1.625 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.375,-1.625],
-									[-0.375,-1.625]
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.375,-1.625]
+								"offset": [ -0.375, -1.625 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -2890,48 +2898,48 @@
 			"actor2-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -2944,48 +2952,48 @@
 			"actor2-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -3008,372 +3016,372 @@
 					"actors": {
 						"idle": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"idle_laying": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-0.625],
-									[0.625,-0.375],
-									[0.5,-0.5],
-									[0.5,-0.625],
-									[0.5,-0.625]
+									[ 0.75, -0.625 ],
+									[ 0.625, -0.375 ],
+									[ 0.5, -0.5 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.75,-0.625]
+								"offset": [ 0.75, -0.625 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-0.625],
-									[0.625,-0.375],
-									[0.625,-0.375],
-									[0.5,-0.5],
-									[0.5,-0.5],
-									[0.5,-0.5],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625]
+									[ 0.75, -0.625 ],
+									[ 0.625, -0.375 ],
+									[ 0.625, -0.375 ],
+									[ 0.5, -0.5 ],
+									[ 0.5, -0.5 ],
+									[ 0.5, -0.5 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.75,-0.625]
+								"offset": [ 0.75, -0.625 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.75],
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.25,-1.875],
-									[1.125,-1.875]
+									[ 1, -1.75 ],
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.125, -1.875 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.875,-2]
+								"offset": [ 0.875, -2 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.75],
-									[1,-1.875],
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875]
+									[ 1, -1.75 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.875,-2]
+								"offset": [ 0.875, -2 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875]
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875]
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.75],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.75],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.75],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[0.125,0],
-									[0.125,-0.125],
-									[0.25,-0.125],
-									[0.25,0],
-									[0.25,0]
+									[ 0.125, 0 ],
+									[ 0.125, -0.125 ],
+									[ 0.25, -0.125 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.125,-0.325]
+								"offset": [ 0.125, -0.325 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,0],
-									[0.125,-0.125],
-									[0.125,-0.125],
-									[0.25,-0.125],
-									[0.25,-0.125],
-									[0.25,-0.125],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0]
+									[ 0.125, 0 ],
+									[ 0.125, -0.125 ],
+									[ 0.125, -0.125 ],
+									[ 0.25, -0.125 ],
+									[ 0.25, -0.125 ],
+									[ 0.25, -0.125 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.125,-0.325]
+								"offset": [ 0.125, -0.325 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.625],
-									[-0.625,-1.625],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.625,-1.625]
+									[ -0.625, -1.625 ],
+									[ -0.625, -1.625 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.625, -1.625 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.625,-1.625]
+								"offset": [ -0.625, -1.625 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.625],
-									[-0.625,-1.625],
-									[-0.625,-1.625],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.625,-1.625],
-									[-0.625,-1.625]
+									[ -0.625, -1.625 ],
+									[ -0.625, -1.625 ],
+									[ -0.625, -1.625 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.625, -1.625 ],
+									[ -0.625, -1.625 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.625,-1.625]
+								"offset": [ -0.625, -1.625 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -3417,71 +3425,71 @@
 			"actor1": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position2": {},
-						"position3": {},
-						"position4": {},
-						"position4_1": {},
-						"position4_2": {},
-						"position5": {},
-						"position6": {},
-						"position7": {},
-						"position8": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position2": { },
+						"position3": { },
+						"position4": { },
+						"position4_1": { },
+						"position4_2": { },
+						"position5": { },
+						"position6": { },
+						"position7": { },
+						"position8": { }
 					}
 				},
 				"properties": {
 					"centered": true,
 					"anchorPart": "actors-inner",
-					"offset": [0,0]
+					"offset": [ 0, 0 ]
 				}
 			},
 			"actor1-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -3494,48 +3502,48 @@
 			"actor1-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -3548,48 +3556,48 @@
 			"actor1-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -3602,48 +3610,48 @@
 			"actor1-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -3656,206 +3664,214 @@
 			"actor1-body": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": {
+							"properties": {
+								"offset": [ -0.5, 0 ]
+							}
+						},
+						"idle": {
+							"properties": {
+								"offset": [ -0.5, 0 ]
+							}
+						},
 						"position1": {
 							"properties": {
-								"offset": [-0.375,0]
+								"offset": [ -0.375, 0 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.375,0]
+								"offset": [ -0.375, 0 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [-0.375,0]
+								"offset": [ -0.375, 0 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.375,0]
+								"offset": [ -0.375, 0 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [-0.875,0]
+								"offset": [ -0.875, 0 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.875,0]
+								"offset": [ -0.875, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [-0.875,0]
+								"offset": [ -0.875, 0 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.875,0]
+								"offset": [ -0.875, 0 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [-1.125,0]
+								"offset": [ -1.125, 0 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [-1.125,0]
+								"offset": [ -1.125, 0 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [-1.125,0]
+								"offset": [ -1.125, 0 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [-1.125,0]
+								"offset": [ -1.125, 0 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						}
 					}
@@ -3873,48 +3889,48 @@
 			"actor1-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -3929,145 +3945,145 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-postclimax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,-0.375]
+								"offset": [ 0, -0.375 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,-0.375]
+								"offset": [ 0, -0.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,-0.375]
+								"offset": [ 0, -0.375 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,-0.375]
+								"offset": [ 0, -0.375 ]
 							}
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-postclimax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-postclimax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-postclimax": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -4080,78 +4096,78 @@
 				"partStates": {
 					"actors": {
 						"position1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position2": {
-							"properties": {}
+							"properties": { }
 						},
 						"position2-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,-0.25]
+								"offset": [ 0, -0.25 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,-0.25]
+								"offset": [ 0, -0.25 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,-0.25]
+								"offset": [ 0, -0.25 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,-0.25]
+								"offset": [ 0, -0.25 ]
 							}
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -4163,48 +4179,48 @@
 			"actor1-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -4217,48 +4233,48 @@
 			"actor1-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -4271,176 +4287,184 @@
 			"actor1-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": {
+							"properties": {
+								"offset": [ 0.125, -1.25 ]
+							}
+						},
+						"idle": {
+							"properties": {
+								"offset": [ 0.125, -1.25 ]
+							}
+						},
 						"position1": {
 							"properties": {
-								"offset": [0.25,-1.25]
+								"offset": [ 0.25, -1.25 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.25,-1.25]
+								"offset": [ 0.25, -1.25 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [0.25,-1.25]
+								"offset": [ 0.25, -1.25 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.25,-1.25]
+								"offset": [ 0.25, -1.25 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0.5,-1.75]
+								"offset": [ 0.5, -1.75 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.5,-1.75]
+								"offset": [ 0.5, -1.75 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0.5,-1.75]
+								"offset": [ 0.5, -1.75 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.5,-1.75]
+								"offset": [ 0.5, -1.75 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0.125,-1.25]
+								"offset": [ 0.125, -1.25 ]
 							}
 						},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -4464,368 +4488,368 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
-						"idle": {},
+						"idle": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,0],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125]
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,0],
-									[-0.125,0],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125]
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375]
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.125,-0.375]
+								"offset": [ -0.125, -0.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375]
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.125,-0.375]
+								"offset": [ -0.125, -0.375 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.5],
-									[0.375,-0.625]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.25,-0.625]
+								"offset": [ 0.25, -0.625 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.25,-0.625]
+								"offset": [ 0.25, -0.625 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-1.25,-2]
+								"offset": [ -1.25, -2 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[0,0],
-									[0,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0]
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,0],
-									[0,0],
-									[0,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0]
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7": {
 							"frameProperties": {
 								"offset": [
-									[-1.25,-2],
-									[-1.25,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.25,-2]
+									[ -1.25, -2 ],
+									[ -1.25, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.25, -2 ]
 								]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [-1.25,-2]
+								"offset": [ -1.25, -2 ]
 							}
 						},
 						"position7-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1.25,-2],
-									[-1.25,-2],
-									[-1.25,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.25,-2],
-									[-1.25,-2]
+									[ -1.25, -2 ],
+									[ -1.25, -2 ],
+									[ -1.25, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.25, -2 ],
+									[ -1.25, -2 ]
 								]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [-1.25,-2]
+								"offset": [ -1.25, -2 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -4839,48 +4863,48 @@
 			"actor1-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -4896,48 +4920,48 @@
 			"actor1-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -4950,48 +4974,48 @@
 			"actor1-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -5004,54 +5028,54 @@
 			"actor1-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
 					"anchorPart": "actor1-head",
 					"centered": true,
-					"offset": [0,0],
+					"offset": [ 0, 0 ],
 					"zLevel": 99
 				}
 			},
@@ -5060,372 +5084,372 @@
 					"actors": {
 						"idle": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"idle_laying": {
 							"properties": {
-								"offset": [0.5,-1]
+								"offset": [ 0.5, -1 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.25],
-									[0.125,-0.5],
-									[0.125,-0.625],
-									[0.125,-0.625]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.25,-0.375]
+								"offset": [ 0.25, -0.375 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.25,-0.375]
+								"offset": [ 0.25, -0.375 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.75],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.75]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.75 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.25,-0.75]
+								"offset": [ 0.25, -0.75 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.75],
-									[0.25,-0.75],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.75],
-									[0.25,-0.75]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.75 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.25,-0.75]
+								"offset": [ 0.25, -0.75 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.825],
-									[0.5,-1],
-									[0.5,-1.125],
-									[0.375,-1],
-									[0.5,-1.125]
+									[ 0.5, -0.825 ],
+									[ 0.5, -1 ],
+									[ 0.5, -1.125 ],
+									[ 0.375, -1 ],
+									[ 0.5, -1.125 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.5,-1]
+								"offset": [ 0.5, -1 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.825],
-									[0.5,-1],
-									[0.5,-1],
-									[0.5,-1.125],
-									[0.5,-1.125],
-									[0.5,-1.125],
-									[0.375,-1],
-									[0.375,-1],
-									[0.375,-1],
-									[0.375,-1],
-									[0.375,-1],
-									[0.5,-1.125],
-									[0.5,-1.125]
+									[ 0.5, -0.825 ],
+									[ 0.5, -1 ],
+									[ 0.5, -1 ],
+									[ 0.5, -1.125 ],
+									[ 0.5, -1.125 ],
+									[ 0.5, -1.125 ],
+									[ 0.375, -1 ],
+									[ 0.375, -1 ],
+									[ 0.375, -1 ],
+									[ 0.375, -1 ],
+									[ 0.375, -1 ],
+									[ 0.5, -1.125 ],
+									[ 0.5, -1.125 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.5,-1]
+								"offset": [ 0.5, -1 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -5439,48 +5463,48 @@
 			"actor1-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -5495,372 +5519,372 @@
 					"actors": {
 						"idle": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"idle_laying": {
 							"properties": {
-								"offset": [0.75,-1]
+								"offset": [ 0.75, -1 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.25],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.5,-0.375]
+								"offset": [ 0.5, -0.375 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.25],
-									[0.375,-0.25],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.5,-0.375]
+								"offset": [ 0.5, -0.375 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.75],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.75]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.75 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.5,-0.75]
+								"offset": [ 0.5, -0.75 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.75],
-									[0.5,-0.75],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.75],
-									[0.5,-0.75]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.75 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.5,-0.75]
+								"offset": [ 0.5, -0.75 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-0.825],
-									[0.75,-1],
-									[0.75,-1.125],
-									[0.625,-1],
-									[0.75,-1.125]
+									[ 0.75, -0.825 ],
+									[ 0.75, -1 ],
+									[ 0.75, -1.125 ],
+									[ 0.625, -1 ],
+									[ 0.75, -1.125 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.75,-1]
+								"offset": [ 0.75, -1 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-0.825],
-									[0.75,-1],
-									[0.75,-1],
-									[0.75,-1.125],
-									[0.75,-1.125],
-									[0.75,-1.125],
-									[0.625,-1],
-									[0.625,-1],
-									[0.625,-1],
-									[0.625,-1],
-									[0.625,-1],
-									[0.75,-1.125],
-									[0.75,-1.125]
+									[ 0.75, -0.825 ],
+									[ 0.75, -1 ],
+									[ 0.75, -1 ],
+									[ 0.75, -1.125 ],
+									[ 0.75, -1.125 ],
+									[ 0.75, -1.125 ],
+									[ 0.625, -1 ],
+									[ 0.625, -1 ],
+									[ 0.625, -1 ],
+									[ 0.625, -1 ],
+									[ 0.625, -1 ],
+									[ 0.75, -1.125 ],
+									[ 0.75, -1.125 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.75,-1]
+								"offset": [ 0.75, -1 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -5912,44 +5936,44 @@
 			"actor3-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -5962,44 +5986,44 @@
 			"actor3-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -6012,23 +6036,23 @@
 			"actor3": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position2": {},
-						"position3": {},
-						"position4": {},
-						"position4_1": {},
-						"position5": {},
-						"position6": {},
-						"position7": {},
-						"position8": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position2": { },
+						"position3": { },
+						"position4": { },
+						"position4_1": { },
+						"position5": { },
+						"position6": { },
+						"position7": { },
+						"position8": { }
 					}
 				},
 				"properties": {
 					"centered": true,
 					"anchorPart": "actors-inner",
-					"offset": [0,0]
+					"offset": [ 0, 0 ]
 				}
 			},
 			"actor3-body": {
@@ -6036,200 +6060,200 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [-1.0,0]
+								"offset": [ -1.0, 0 ]
 							}
 						},
 						"idle": {
 							"properties": {
-								"offset": [-1.5,0]
+								"offset": [ -1.5, 0 ]
 							}
 						},
 						"position1": {
 							"properties": {
-								"offset": [1.25,0],
+								"offset": [ 1.25, 0 ],
 								"zLevel": 31
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [1.25,0],
+								"offset": [ 1.25, 0 ],
 								"zLevel": 31
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [1.25,0],
+								"offset": [ 1.25, 0 ],
 								"zLevel": 31
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [1.25,0],
+								"offset": [ 1.25, 0 ],
 								"zLevel": 31
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [-1.75,0]
+								"offset": [ -1.75, 0 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-1.75,0]
+								"offset": [ -1.75, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [-1.75,0]
+								"offset": [ -1.75, 0 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-1.75,0]
+								"offset": [ -1.75, 0 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [1.5,-0.125],
+								"offset": [ 1.5, -0.125 ],
 								"zLevel": 23
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [1.5,-0.125],
+								"offset": [ 1.5, -0.125 ],
 								"zLevel": 23
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [1.5,-0.125],
+								"offset": [ 1.5, -0.125 ],
 								"zLevel": 23
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [1.5,-0.125],
+								"offset": [ 1.5, -0.125 ],
 								"zLevel": 23
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [-1.625,0]
+								"offset": [ -1.625, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-1.625,0]
+								"offset": [ -1.625, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [-1.625,0]
+								"offset": [ -1.625, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-1.625,0]
+								"offset": [ -1.625, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -6247,44 +6271,44 @@
 			"actor3-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -6297,44 +6321,44 @@
 			"actor3-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -6347,44 +6371,44 @@
 			"actor3-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -6397,85 +6421,85 @@
 			"actor3-climax-with-penis": {
 				"partStates": {
 					"actors": {
-						"position1": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
+						"position1": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
 						"position4": {
 							"properties": {
-								"offset": [-1,0]
+								"offset": [ -1, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-1,0]
+								"offset": [ -1, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [-1,0]
+								"offset": [ -1, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-1,0]
+								"offset": [ -1, 0 ]
 							}
 						},
 						"position4_1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position5": {
-							"properties": {}
+							"properties": { }
 						},
 						"position5-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -6488,64 +6512,64 @@
 				"partStates": {
 					"actors": {
 						"position1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position2": {
-							"properties": {}
+							"properties": { }
 						},
 						"position2-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position5": {
-							"properties": {}
+							"properties": { }
 						},
 						"position5-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -6557,44 +6581,44 @@
 			"actor3-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -6607,44 +6631,44 @@
 			"actor3-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -6668,108 +6692,116 @@
 			"actor3-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": {
+							"properties": {
+								"offset": [ 0.125, -1.25 ]
+							}
+						},
+						"idle": {
+							"properties": {
+								"offset": [ 0.125, -1.25 ]
+							}
+						},
 						"position1": {
 							"properties": {
-								"offset": [-0.375,-1.75]
+								"offset": [ -0.375, -1.75 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.375,-1.75]
+								"offset": [ -0.375, -1.75 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [-0.375,-1.75]
+								"offset": [ -0.375, -1.75 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.375,-1.75]
+								"offset": [ -0.375, -1.75 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0.25,-1.25]
+								"offset": [ 0.25, -1.25 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.25,-1.25]
+								"offset": [ 0.25, -1.25 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0.25,-1.25]
+								"offset": [ 0.25, -1.25 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.25,-1.25]
+								"offset": [ 0.25, -1.25 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,-1.75]
+								"offset": [ 0, -1.75 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [-0.375,-1.75]
+								"offset": [ -0.375, -1.75 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.375,-1.75]
+								"offset": [ -0.375, -1.75 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [-0.375,-1.75]
+								"offset": [ -0.375, -1.75 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.375,-1.75]
+								"offset": [ -0.375, -1.75 ]
 							}
 						},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -6780,366 +6812,366 @@
 			"actor3-head": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": { },
+						"idle": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.625,-1.5],
-									[0.75,-1.5],
-									[0.875,-1.375],
-									[1,-1.375],
-									[0.875,-1.5]
+									[ 0.625, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.875, -1.375 ],
+									[ 1, -1.375 ],
+									[ 0.875, -1.5 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.625,-1.5]
+								"offset": [ 0.625, -1.5 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.625,-1.5],
-									[0.75,-1.5],
-									[0.75,-1.5],
-									[0.875,-1.375],
-									[0.875,-1.375],
-									[0.875,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[0.875,-1.5],
-									[0.875,-1.5]
+									[ 0.625, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.875, -1.375 ],
+									[ 0.875, -1.375 ],
+									[ 0.875, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 0.875, -1.5 ],
+									[ 0.875, -1.5 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.625,-1.5]
+								"offset": [ 0.625, -1.5 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,0],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125]
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,0],
-									[-0.125,0],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125]
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375]
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.125,-0.375]
+								"offset": [ -0.125, -0.375 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375]
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.125,-0.375]
+								"offset": [ -0.125, -0.375 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[-0.25,0.125],
-									[-0.25,0.25],
-									[-0.125,0.375],
-									[-0.125,0.5],
-									[-0.125,0.375]
+									[ -0.25, 0.125 ],
+									[ -0.25, 0.25 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.375 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.25,0.125]
+								"offset": [ -0.25, 0.125 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.25,0.125],
-									[-0.25,0.25],
-									[-0.25,0.25],
-									[-0.125,0.375],
-									[-0.125,0.375],
-									[-0.125,0.375],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.375],
-									[-0.125,0.375]
+									[ -0.25, 0.125 ],
+									[ -0.25, 0.25 ],
+									[ -0.25, 0.25 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.25,0.125]
+								"offset": [ -0.25, 0.125 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position7": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position7-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position8": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position8-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						}
 					}
@@ -7153,44 +7185,44 @@
 			"actor3-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -7206,44 +7238,44 @@
 			"actor3-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -7256,48 +7288,48 @@
 			"actor3-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -7310,44 +7342,44 @@
 			"actor3-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -7360,50 +7392,50 @@
 			"actor3-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
 					"anchorPart": "actor3-head",
 					"centered": true,
-					"offset": [0,0],
+					"offset": [ 0, 0 ],
 					"zLevel": 99
 				}
 			},
@@ -7412,193 +7444,193 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.75],
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[1,-1.875],
-									[0.875,-1.875]
+									[ 0.75, -1.75 ],
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 1, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.75],
-									[0.75,-1.875],
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875]
+									[ 0.75, -1.75 ],
+									[ 0.75, -1.875 ],
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.25],
-									[0.125,-0.5],
-									[0.125,-0.625],
-									[0.125,-0.625]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.25,-0.375]
+								"offset": [ 0.25, -0.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.25,-0.375]
+								"offset": [ 0.25, -0.375 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.75],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.75],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.75]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.25,-0.75]
+								"offset": [ 0.25, -0.75 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.75],
-									[0.25,-0.75],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.75],
-									[0.25,-0.75]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.25,-0.75]
+								"offset": [ 0.25, -0.75 ]
 							}
 						},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -7619,193 +7651,193 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.75],
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.25,-1.875],
-									[1.125,-1.875]
+									[ 1, -1.75 ],
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.125, -1.875 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.875,-2]
+								"offset": [ 0.875, -2 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.75],
-									[1,-1.875],
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875]
+									[ 1, -1.75 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.875,-2]
+								"offset": [ 0.875, -2 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.25],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.5,-0.375]
+								"offset": [ 0.5, -0.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.25],
-									[0.375,-0.25],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.5,-0.375]
+								"offset": [ 0.5, -0.375 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.75],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.75],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.75]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.5,-0.75]
+								"offset": [ 0.5, -0.75 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.75],
-									[0.5,-0.75],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.75],
-									[0.5,-0.75]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.5,-0.75]
+								"offset": [ 0.5, -0.75 ]
 							}
 						},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -7846,86 +7878,86 @@
 			"actors-overlay1": {
 				"partStates": {
 					"actors": {
-						"position1": {},
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -7938,86 +7970,86 @@
 			"actors-overlay3": {
 				"partStates": {
 					"actors": {
-						"position1": {},
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -8030,86 +8062,86 @@
 			"actors-overlay2": {
 				"partStates": {
 					"actors": {
-						"position1": {},
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position8-postclimax": {},
-						"position8-reset": {}
+						"position8-postclimax": { },
+						"position8-reset": { }
 					}
 				},
 				"properties": {
@@ -8459,7 +8491,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position1-climax": {
@@ -8473,7 +8505,7 @@
 						"mode": "transition",
 						"transition": "position1",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position1-reset": {
@@ -8486,7 +8518,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position2-climax": {
@@ -8500,7 +8532,7 @@
 						"mode": "transition",
 						"transition": "position2",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position2-reset": {
@@ -8513,7 +8545,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position3-climax": {
@@ -8527,7 +8559,7 @@
 						"mode": "transition",
 						"transition": "position3",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position3-reset": {
@@ -8540,7 +8572,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4-climax": {
@@ -8554,7 +8586,7 @@
 						"mode": "transition",
 						"transition": "position4",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4-reset": {
@@ -8567,7 +8599,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4_1-climax": {
@@ -8581,7 +8613,7 @@
 						"mode": "transition",
 						"transition": "position4_1",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4_1-reset": {
@@ -8594,7 +8626,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4_2-climax": {
@@ -8608,7 +8640,7 @@
 						"mode": "transition",
 						"transition": "position4_2",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4_2-reset": {
@@ -8621,7 +8653,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position5-climax": {
@@ -8635,7 +8667,7 @@
 						"mode": "transition",
 						"transition": "position5",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position5-reset": {
@@ -8648,7 +8680,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position6-climax": {
@@ -8662,7 +8694,7 @@
 						"mode": "transition",
 						"transition": "position6",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position6-reset": {
@@ -8675,7 +8707,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position7-climax": {
@@ -8689,7 +8721,7 @@
 						"mode": "transition",
 						"transition": "position7",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position7-reset": {
@@ -8702,7 +8734,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position8-climax": {
@@ -8716,7 +8748,7 @@
 						"mode": "transition",
 						"transition": "position8",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position8-reset": {
@@ -8724,7 +8756,7 @@
 						"cycle": 1,
 						"mode": "loop"
 					},
-					"none": {}
+					"none": { }
 				},
 				"default": "none",
 				"properties": {
@@ -8953,7 +8985,7 @@
 						"cycle": 1,
 						"mode": "loop"
 					},
-					"none": {}
+					"none": { }
 				},
 				"default": "idle",
 				"properties": {
@@ -8962,7 +8994,7 @@
 			},
 			"clock": {
 				"states": {
-					"none": {},
+					"none": { },
 					"cycle1": {
 						"frames": 1,
 						"cycle": 1,
@@ -8985,392 +9017,413 @@
 			"anchorPart": "actor2-nipple1",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor2-lactation-spew1": {
 			"anchorPart": "actor2-nipple1",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"actor2-lactation-drip2": {
 			"anchorPart": "actor2-nipple2",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor2-lactation-spew2": {
 			"anchorPart": "actor2-nipple2",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"climaxbutterflymale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflymale2"}
+				{ "particle": "climaxbutterflymale2" }
 			]
 		},
 		"climaxbutterflyfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflyfemale2"}
+				{ "particle": "climaxbutterflyfemale2" }
 			]
 		},
 		"climaxcowgirlmale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlmale2"}
+				{ "particle": "climaxcowgirlmale2" }
 			]
 		},
 		"climaxcowgirlfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlfemale2"}
+				{ "particle": "climaxcowgirlfemale2" }
 			]
 		},
 		"climaxdoggymale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale2"}
+				{ "particle": "climaxdoggymale2" }
 			]
 		},
 		"climaxdoubledoggymale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale2"}
+				{ "particle": "climaxdoggymale2" }
 			]
 		},
 		"climaxdoggyfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale2"}
+				{ "particle": "climaxdoggyfemale2" }
 			]
 		},
 		"climaxdoubledoggyfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale2"}
+				{ "particle": "climaxdoggyfemale2" }
 			]
 		},
 		"climaxfacesittingmale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfacesittingmale2"}
+				{ "particle": "climaxfacesittingmale2" }
 			]
 		},
 		"climaxfacesittingfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfacesittingfemale2"}
+				{ "particle": "climaxfacesittingfemale2" }
 			]
 		},
 		"climaxfellatiomale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiomale2"}
+				{ "particle": "climaxfellatiomale2" }
 			]
 		},
 		"climaxfellatiofemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiofemale2"}
+				{ "particle": "climaxfellatiofemale2" }
 			]
 		},
 		"climaxmissionarymale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionarymale2"}
+				{ "particle": "climaxmissionarymale2" }
 			]
 		},
 		"climaxmissionaryfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionaryfemale2"}
+				{ "particle": "climaxmissionaryfemale2" }
 			]
 		},
 		"climaxstandingmale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingmale2"}
+				{ "particle": "climaxstandingmale2" }
 			]
 		},
 		"climaxstandingfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingfemale2"}
+				{ "particle": "climaxstandingfemale2" }
 			]
 		},
 		"actor1-lactation-drip1": {
 			"anchorPart": "actor1-nipple1",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor1-lactation-spew1": {
 			"anchorPart": "actor1-nipple1",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"actor1-lactation-drip2": {
 			"anchorPart": "actor1-nipple2",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor1-lactation-spew2": {
 			"anchorPart": "actor1-nipple2",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"climaxbutterflymale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflymale1"}
+				{ "particle": "climaxbutterflymale1" }
 			]
 		},
 		"climaxbutterflyfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflyfemale1"}
+				{ "particle": "climaxbutterflyfemale1" }
 			]
 		},
 		"climaxcowgirlmale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlmale1"}
+				{ "particle": "climaxcowgirlmale1" }
 			]
 		},
 		"climaxcowgirlfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlfemale1"}
+				{ "particle": "climaxcowgirlfemale1" }
 			]
 		},
 		"climaxdoggymale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale1"}
+				{ "particle": "climaxdoggymale1" }
 			]
 		},
 		"climaxdoubledoggymale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale2"}
+				{ "particle": "climaxdoggymale2" }
 			]
 		},
 		"climaxdoggyfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale1"}
+				{ "particle": "climaxdoggyfemale1" }
 			]
 		},
 		"climaxdoubledoggyfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale2"}
+				{ "particle": "climaxdoggyfemale2" }
 			]
 		},
 		"climaxfacesittingmale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfacesittingmale1"}
+				{ "particle": "climaxfacesittingmale1" }
 			]
 		},
 		"climaxfacesittingfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfacesittingfemale1"}
+				{ "particle": "climaxfacesittingfemale1" }
+			]
+		},
+		"insemination-drip1": {
+			"anchorPart": "actor1-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
+			]
+		},
+		"insemination-drip2": {
+			"anchorPart": "actor2-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
+			]
+		},
+		"insemination-drip3": {
+			"anchorPart": "actor3-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
 			]
 		},
 		"climaxfellatiomale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiomale1"}
+				{ "particle": "climaxfellatiomale1" }
 			]
 		},
 		"climaxfellatiofemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiofemale1"}
+				{ "particle": "climaxfellatiofemale1" }
 			]
 		},
 		"climaxmissionarymale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionarymale1"}
+				{ "particle": "climaxmissionarymale1" }
 			]
 		},
 		"climaxmissionaryfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionaryfemale1"}
+				{ "particle": "climaxmissionaryfemale1" }
 			]
 		},
 		"climaxstandingmale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingmale1"}
+				{ "particle": "climaxstandingmale1" }
 			]
 		},
 		"climaxstandingfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingfemale1"}
+				{ "particle": "climaxstandingfemale1" }
 			]
 		},
 		"actor3-lactation-drip1": {
 			"anchorPart": "actor3-nipple1",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor3-lactation-spew1": {
 			"anchorPart": "actor3-nipple1",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"actor3-lactation-drip2": {
 			"anchorPart": "actor3-nipple2",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor3-lactation-spew2": {
 			"anchorPart": "actor3-nipple2",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"climaxbutterflymale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflymale2"}
+				{ "particle": "climaxbutterflymale2" }
 			]
 		},
 		"climaxbutterflyfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflyfemale2"}
+				{ "particle": "climaxbutterflyfemale2" }
 			]
 		},
 		"climaxcowgirlmale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale1"}
+				{ "particle": "climaxdoggymale1" }
 			]
 		},
 		"climaxcowgirlfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale1"}
+				{ "particle": "climaxdoggyfemale1" }
 			]
 		},
 		"climaxdoggymale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingmale1"}
+				{ "particle": "climaxstandingmale1" }
 			]
 		},
 		"climaxdoggyfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingfemale1"}
+				{ "particle": "climaxstandingfemale1" }
 			]
 		},
 		"climaxfellatiomale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiomale2"}
+				{ "particle": "climaxfellatiomale2" }
 			]
 		},
 		"climaxfellatiofemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiofemale2"}
+				{ "particle": "climaxfellatiofemale2" }
 			]
 		},
 		"climaxmissionarymale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlmale2"}
+				{ "particle": "climaxcowgirlmale2" }
 			]
 		},
 		"climaxmissionaryfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlfemale2"}
+				{ "particle": "climaxcowgirlfemale2" }
 			]
 		},
 		"climaxstandingmale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale2"}
+				{ "particle": "climaxdoggymale2" }
 			]
 		},
 		"climaxstandingfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale2"}
+				{ "particle": "climaxdoggyfemale2" }
 			]
 		},
 		"emotehappy": {
@@ -9380,9 +9433,9 @@
 					"particle": {
 						"type": "animated",
 						"animation": "/animations/emotes/happy.animation",
-						"position": [0,0],
-						"finalVelocity": [0,0],
-						"initialVelocity": [0,0],
+						"position": [ 0, 0 ],
+						"finalVelocity": [ 0, 0 ],
+						"initialVelocity": [ 0, 0 ],
 						"destructionTime": 0.2,
 						"destructionAction": "shrink",
 						"layer": "front",
@@ -9394,32 +9447,32 @@
 		}
 	},
 	"transformationGroups": {
-		"actor2Body":			{"interpolated": true},
-		"actor2Groinwear1":		{"interpolated": true},
-		"actor2Head":			{"interpolated": true},
-		"actor2Nippleswear1":	{"interpolated": true},
-		"actor2Nippleswear2":	{"interpolated": true},
-		"actor1Body":			{"interpolated": true},
-		"actor1Groinwear1":		{"interpolated": true},
-		"actor1Head":			{"interpolated": true},
-		"actor1Nippleswear1":	{"interpolated": true},
-		"actor1Nippleswear2":	{"interpolated": true},
-		"actor3Body":			{"interpolated": true},
-		"actor3Groinwear1":		{"interpolated": true},
-		"actor3Head":			{"interpolated": true},
-		"actor3Nippleswear1":	{"interpolated": true},
-		"actor3Nippleswear2":	{"interpolated": true},
-		"actors":				{"interpolated": true}
+		"actor2Body": { "interpolated": true },
+		"actor2Groinwear1": { "interpolated": true },
+		"actor2Head": { "interpolated": true },
+		"actor2Nippleswear1": { "interpolated": true },
+		"actor2Nippleswear2": { "interpolated": true },
+		"actor1Body": { "interpolated": true },
+		"actor1Groinwear1": { "interpolated": true },
+		"actor1Head": { "interpolated": true },
+		"actor1Nippleswear1": { "interpolated": true },
+		"actor1Nippleswear2": { "interpolated": true },
+		"actor3Body": { "interpolated": true },
+		"actor3Groinwear1": { "interpolated": true },
+		"actor3Head": { "interpolated": true },
+		"actor3Nippleswear1": { "interpolated": true },
+		"actor3Nippleswear2": { "interpolated": true },
+		"actors": { "interpolated": true }
 	},
 	"sounds": {
-		"actor1moan":	[],
-		"actor2moan":	[],
-		"actor3moan":	[],
-		"actor4moan":	[],
-		"actor1orgasm":	[],
-		"actor2orgasm":	[],
-		"actor3orgasm":	[],
-		"actor4orgasm":	[],
-		"climax":		[]
+		"actor1moan": [ ],
+		"actor2moan": [ ],
+		"actor3moan": [ ],
+		"actor4moan": [ ],
+		"actor1orgasm": [ ],
+		"actor2orgasm": [ ],
+		"actor3orgasm": [ ],
+		"actor4orgasm": [ ],
+		"climax": [ ]
 	}
 }

--- a/artwork/humanoid/twoactors-org.animation
+++ b/artwork/humanoid/twoactors-org.animation
@@ -615,83 +615,83 @@
 			"actors-overlay1": {
 				"partStates": {
 					"actors": {
-						"position0": {},
+						"position0": { },
 						"position0-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position0-reset": {},
-						"position1": {},
+						"position0-reset": { },
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position1-reset": {},
-						"position2": {},
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position2-reset": {},
-						"position3": {},
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position3-reset": {},
-						"position4": {},
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position5-reset": {},
-						"position6": {},
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position6-reset": {},
-						"position7": {},
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position7-reset": {},
-						"position8": {},
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position8-reset": {},
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"image": "<part-overlay1>.r"
@@ -709,83 +709,83 @@
 			"actors-overlay3": {
 				"partStates": {
 					"actors": {
-						"position0": {},
+						"position0": { },
 						"position0-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position0-reset": {},
-						"position1": {},
+						"position0-reset": { },
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position1-reset": {},
-						"position2": {},
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position2-reset": {},
-						"position3": {},
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position3-reset": {},
-						"position4": {},
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position5-reset": {},
-						"position6": {},
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position6-reset": {},
-						"position7": {},
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position7-reset": {},
-						"position8": {},
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position8-reset": {},
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"image": "<part-overlay3>.r"
@@ -803,83 +803,83 @@
 			"actors-overlay2": {
 				"partStates": {
 					"actors": {
-						"position0": {},
+						"position0": { },
 						"position0-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position0-reset": {},
-						"position1": {},
+						"position0-reset": { },
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position1-reset": {},
-						"position2": {},
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position2-reset": {},
-						"position3": {},
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position3-reset": {},
-						"position4": {},
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position5-reset": {},
-						"position6": {},
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position6-reset": {},
-						"position7": {},
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position7-reset": {},
-						"position8": {},
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position8-reset": {},
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"image": "<part-overlay2>.r"
@@ -897,42 +897,42 @@
 			"actor2-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -945,42 +945,42 @@
 			"actor2-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -993,42 +993,42 @@
 			"actor2-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -1041,7 +1041,7 @@
 			"actor2-body": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
+						"idle_laying": { },
 						"idle": {
 							"properties": {
 								"offset": [
@@ -1050,9 +1050,9 @@
 								]
 							}
 						},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
 						"position1": {
 							"properties": {
 								"offset": [
@@ -1316,42 +1316,42 @@
 			"actor2-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -1753,10 +1753,10 @@
 				"partStates": {
 					"actors": {
 						"position0": {
-							"properties": {}
+							"properties": { }
 						},
 						"position0-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1": {
 							"properties": {
@@ -1951,16 +1951,16 @@
 							}
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position-birthing": {
 							"properties": {
@@ -1980,42 +1980,42 @@
 			"actor2-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2029,10 +2029,10 @@
 				"partStates": {
 					"actors": {
 						"position0": {
-							"properties": {}
+							"properties": { }
 						},
 						"position0-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1": {
 							"properties": {
@@ -2083,10 +2083,10 @@
 							}
 						},
 						"position3": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4": {
 							"properties": {
@@ -2185,25 +2185,25 @@
 							}
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position-birthing": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -2215,42 +2215,42 @@
 			"actor2-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2263,29 +2263,29 @@
 			"actor2-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
 						"position5": {
 							"frameProperties": {
 								"zLevel": [
@@ -2311,16 +2311,16 @@
 								]
 							}
 						},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2333,7 +2333,7 @@
 			"actor2-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
+						"idle_laying": { },
 						"idle": {
 							"properties": {
 								"offset": [
@@ -2558,12 +2558,12 @@
 								]
 							}
 						},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"offset": [
@@ -2593,8 +2593,8 @@
 			"actor2-head": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": { },
+						"idle": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
@@ -3034,42 +3034,42 @@
 			"actor2-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -3085,42 +3085,42 @@
 			"actor2-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -3133,42 +3133,42 @@
 			"actor2-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -3181,42 +3181,42 @@
 			"actor2-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -3229,42 +3229,42 @@
 			"actor2-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -3280,19 +3280,19 @@
 			"actor2": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position1": {},
-						"position2": {},
-						"position3": {},
-						"position4": {},
-						"position4_1": {},
-						"position4_2": {},
-						"position5": {},
-						"position6": {},
-						"position7": {},
-						"position8": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position1": { },
+						"position2": { },
+						"position3": { },
+						"position4": { },
+						"position4_1": { },
+						"position4_2": { },
+						"position5": { },
+						"position6": { },
+						"position7": { },
+						"position8": { }
 					}
 				},
 				"properties": {
@@ -4211,8 +4211,8 @@
 			"actor1": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": { },
+						"idle": { },
 						"position0": {
 							"frameProperties": {
 								"playSound": [
@@ -4269,7 +4269,7 @@
 								]
 							}
 						},
-						"position6": {},
+						"position6": { },
 						"position7": {
 							"frameProperties": {
 								"playSound": [
@@ -4298,42 +4298,42 @@
 			"actor1-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4346,42 +4346,42 @@
 			"actor1-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4394,42 +4394,42 @@
 			"actor1-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4458,9 +4458,9 @@
 								]
 							}
 						},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
 						"position1": {
 							"properties": {
 								"offset": [
@@ -4918,42 +4918,42 @@
 			"actor1-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4967,46 +4967,46 @@
 				"partStates": {
 					"actors": {
 						"position0": {
-							"properties": {}
+							"properties": { }
 						},
 						"position0-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position2": {
-							"properties": {}
+							"properties": { }
 						},
 						"position2-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position5": {
 							"properties": {
@@ -5033,25 +5033,25 @@
 							}
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position-birthing": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -5258,10 +5258,10 @@
 				"partStates": {
 					"actors": {
 						"position0": {
-							"properties": {}
+							"properties": { }
 						},
 						"position0-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1": {
 							"properties": {
@@ -5336,16 +5336,16 @@
 							}
 						},
 						"position4": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2": {
 							"properties": {
@@ -5396,22 +5396,22 @@
 							}
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position-birthing": {
 							"properties": {
@@ -5431,42 +5431,42 @@
 			"actor1-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -5479,7 +5479,7 @@
 			"actor1-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
+						"idle_laying": { },
 						"idle": {
 							"properties": {
 								"offset": [
@@ -5704,12 +5704,12 @@
 								]
 							}
 						},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"offset": [
@@ -5728,42 +5728,42 @@
 			"actor1-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -5795,10 +5795,10 @@
 								]
 							}
 						},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
@@ -6184,42 +6184,42 @@
 			"actor1-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6235,42 +6235,42 @@
 			"actor1-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6283,42 +6283,42 @@
 			"actor1-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6331,42 +6331,42 @@
 			"actor1-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6382,42 +6382,42 @@
 			"actor1-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6899,9 +6899,9 @@
 			"actor3": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
 						"position1": {
 							"properties": {
 								"offset": [
@@ -6910,14 +6910,14 @@
 								]
 							}
 						},
-						"position2": {},
-						"position3": {},
-						"position4": {},
-						"position4_1": {},
-						"position5": {},
-						"position6": {},
-						"position7": {},
-						"position8": {}
+						"position2": { },
+						"position3": { },
+						"position4": { },
+						"position4_1": { },
+						"position5": { },
+						"position6": { },
+						"position7": { },
+						"position8": { }
 					}
 				},
 				"properties": {
@@ -6932,39 +6932,39 @@
 			"actor3-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6977,42 +6977,42 @@
 			"actor1-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7025,39 +7025,39 @@
 			"actor3-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7070,7 +7070,7 @@
 			"actor3-body": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
+						"idle_laying": { },
 						"idle": {
 							"properties": {
 								"offset": [
@@ -7079,9 +7079,9 @@
 								]
 							}
 						},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
 						"position1": {
 							"properties": {
 								"offset": [
@@ -7327,39 +7327,39 @@
 			"actor3-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7807,39 +7807,39 @@
 			"actor3-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7853,19 +7853,19 @@
 				"partStates": {
 					"actors": {
 						"position0": {
-							"properties": {}
+							"properties": { }
 						},
 						"position0-climax": {
-							"properties": {}
+							"properties": { }
 						},
-						"position1": {},
-						"position2-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
+						"position1": { },
+						"position2-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
 						"position4": {
 							"properties": {
 								"offset": [
@@ -7891,10 +7891,10 @@
 							}
 						},
 						"position4_1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2": {
 							"properties": {
@@ -7921,28 +7921,28 @@
 							}
 						},
 						"position5": {
-							"properties": {}
+							"properties": { }
 						},
 						"position5-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position-birthing": {
 							"properties": {
@@ -8140,39 +8140,39 @@
 			"actor3-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8186,73 +8186,73 @@
 				"partStates": {
 					"actors": {
 						"position0": {
-							"properties": {}
+							"properties": { }
 						},
 						"position0-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position2": {
-							"properties": {}
+							"properties": { }
 						},
 						"position2-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3": {
-							"properties": {}
+							"properties": { }
 						},
 						"position3-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_1-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2": {
-							"properties": {}
+							"properties": { }
 						},
 						"position4_2-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position5": {
-							"properties": {}
+							"properties": { }
 						},
 						"position5-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6": {
-							"properties": {}
+							"properties": { }
 						},
 						"position6-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7": {
-							"properties": {}
+							"properties": { }
 						},
 						"position7-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8": {
-							"properties": {}
+							"properties": { }
 						},
 						"position8-climax": {
-							"properties": {}
+							"properties": { }
 						},
 						"position-birthing": {
-							"properties": {}
+							"properties": { }
 						}
 					}
 				},
@@ -8264,39 +8264,39 @@
 			"actor3-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8320,11 +8320,11 @@
 			"actor3-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
 						"position1": {
 							"properties": {
 								"offset": [
@@ -8421,21 +8421,21 @@
 								]
 							}
 						},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"offset": [
@@ -8454,39 +8454,39 @@
 			"actor3-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8499,11 +8499,11 @@
 			"actor3-head": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
@@ -8901,39 +8901,39 @@
 			"actor3-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8949,39 +8949,39 @@
 			"actor3-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8994,42 +8994,42 @@
 			"actor3-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -9042,39 +9042,39 @@
 			"actor3-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -9087,39 +9087,39 @@
 			"actor3-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position0": {},
-						"position0-climax": {},
-						"position0-reset": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position0": { },
+						"position0-climax": { },
+						"position0-reset": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -9480,13 +9480,13 @@
 						}
 					},
 					"position-birthing": {
-							"properties": {
-								"offset": [
-									0.75,
-									-1.875
-								]
-							}
+						"properties": {
+							"offset": [
+								0.75,
+								-1.875
+							]
 						}
+					}
 				},
 				"properties": {
 					"anchorPart": "actor3-body",
@@ -10612,7 +10612,7 @@
 						"cycle": 1,
 						"mode": "loop"
 					},
-					"none": {}
+					"none": { }
 				},
 				"default": "none",
 				"properties": {
@@ -10801,7 +10801,7 @@
 						"cycle": 1,
 						"mode": "loop"
 					},
-					"none": {}
+					"none": { }
 				},
 				"default": "idle",
 				"properties": {
@@ -11109,6 +11109,27 @@
 				}
 			]
 		},
+		"insemination-drip1": {
+			"anchorPart": "actor1-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
+			]
+		},
+		"insemination-drip2": {
+			"anchorPart": "actor2-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
+			]
+		},
+		"insemination-drip3": {
+			"anchorPart": "actor3-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
+			]
+		},
 		"climaxfellatiomale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
@@ -11309,15 +11330,15 @@
 		}
 	},
 	"sounds": {
-		"actor1moan": [],
-		"actor2moan": [],
-		"actor3moan": [],
-		"actor4moan": [],
-		"actor1orgasm": [],
-		"actor2orgasm": [],
-		"actor3orgasm": [],
-		"actor4orgasm": [],
-		"climax": []
+		"actor1moan": [ ],
+		"actor2moan": [ ],
+		"actor3moan": [ ],
+		"actor4moan": [ ],
+		"actor1orgasm": [ ],
+		"actor2orgasm": [ ],
+		"actor3orgasm": [ ],
+		"actor4orgasm": [ ],
+		"climax": [ ]
 	},
 	"transformationGroups": {
 		"actors": {

--- a/artwork/humanoid/twoactors.animation
+++ b/artwork/humanoid/twoactors.animation
@@ -164,7 +164,7 @@
 				"properties": {
 					"anchorPart": "root",
 					"centered": false,
-					"offset": [0,-0.125],
+					"offset": [ 0, -0.125 ],
 					"transformationGroups": [
 						"actors"
 					]
@@ -175,20 +175,20 @@
 					"anchorPart": "root",
 					"centered": false,
 					"image": "/artwork/container.png",
-					"offset": [-6,0]
+					"offset": [ -6, 0 ]
 				}
 			},
 			"root": {
 				"properties": {
 					"centered": false,
-					"offset": [0,0]
+					"offset": [ 0, 0 ]
 				}
 			},
 			"actor2-body-center": {
 				"properties": {
 					"centered": false,
 					"anchorPart": "actor2-body",
-					"offset": [2.6875,2.6875]
+					"offset": [ 2.6875, 2.6875 ]
 				}
 			},
 			"actor2-emote": {
@@ -325,7 +325,7 @@
 				"properties": {
 					"centered": false,
 					"anchorPart": "actor1-body",
-					"offset": [2.6875,2.6875]
+					"offset": [ 2.6875, 2.6875 ]
 				}
 			},
 			"actor1-emote": {
@@ -462,7 +462,7 @@
 				"properties": {
 					"centered": false,
 					"anchorPart": "actor3-body",
-					"offset": [2.6875,2.6875]
+					"offset": [ 2.6875, 2.6875 ]
 				}
 			},
 			"actor3-emote": {
@@ -598,86 +598,86 @@
 			"actors-overlay1": {
 				"partStates": {
 					"actors": {
-						"position1": {},
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay1>.r"
 							}
 						},
-						"position8-postclimax": {},
-						"position8-reset": {},
+						"position8-postclimax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"image": "<part-overlay1>.r"
@@ -695,86 +695,86 @@
 			"actors-overlay3": {
 				"partStates": {
 					"actors": {
-						"position1": {},
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay3>.r"
 							}
 						},
-						"position8-postclimax": {},
-						"position8-reset": {},
+						"position8-postclimax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"image": "<part-overlay3>.r"
@@ -792,86 +792,86 @@
 			"actors-overlay2": {
 				"partStates": {
 					"actors": {
-						"position1": {},
+						"position1": { },
 						"position1-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
 						"position2-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
 						"position3-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
 						"position4-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
 						"position4_1-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
 						"position4_2-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
 						"position5-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
 						"position6-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
 						"position7-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
 						"position8-climax": {
 							"properties": {
 								"image": "<part-overlay2>.r"
 							}
 						},
-						"position8-postclimax": {},
-						"position8-reset": {},
+						"position8-postclimax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
 								"image": "<part-overlay2>.r"
@@ -889,49 +889,49 @@
 			"actor2-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -944,49 +944,49 @@
 			"actor2-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -999,49 +999,49 @@
 			"actor2-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -1056,217 +1056,217 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [-1.5,0]
+								"offset": [ -1.5, 0 ]
 							}
 						},
 						"idle": {
 							"properties": {
-								"offset": [-3,0]
+								"offset": [ -3, 0 ]
 							}
 						},
 						"position1": {
 							"properties": {
-								"offset": [0.125,0]
+								"offset": [ 0.125, 0 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.125,0]
+								"offset": [ 0.125, 0 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [0.125,0]
+								"offset": [ 0.125, 0 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.125,0]
+								"offset": [ 0.125, 0 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.25,0]
+								"offset": [ 0.25, 0 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -1284,49 +1284,49 @@
 			"actor2-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -1341,157 +1341,157 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [2.75,1.25]
+								"offset": [ 2.75, 1.25 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [2.75,1.25]
+								"offset": [ 2.75, 1.25 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [2.75,1.25]
+								"offset": [ 2.75, 1.25 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [2.125,0.5]
+								"offset": [ 2.125, 0.5 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [2.125,0.5]
+								"offset": [ 2.125, 0.5 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [2.125,0.5]
+								"offset": [ 2.125, 0.5 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [2.625,1.375]
+								"offset": [ 2.625, 1.375 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [2.625,1.375]
+								"offset": [ 2.625, 1.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [2.625,1.375]
+								"offset": [ 2.625, 1.375 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						}
 					}
@@ -1506,157 +1506,157 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [2.75,0.375]
+								"offset": [ 2.75, 0.375 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [2.75,0.375]
+								"offset": [ 2.75, 0.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [2.75,0.375]
+								"offset": [ 2.75, 0.375 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [3.125,2.125]
+								"offset": [ 3.125, 2.125 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [3.125,2.125]
+								"offset": [ 3.125, 2.125 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [3.125,2.125]
+								"offset": [ 3.125, 2.125 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						}
 					}
@@ -1671,173 +1671,173 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.5,-0.5]
+								"offset": [ 0.5, -0.5 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.75,0]
+								"offset": [ -0.75, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0.5,0.5]
+								"offset": [ 0.5, 0.5 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.5,0.5]
+								"offset": [ 0.5, 0.5 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0.5,0.5]
+								"offset": [ 0.5, 0.5 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.5,0.5]
+								"offset": [ 0.5, 0.5 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [-0.5,0.5]
+								"offset": [ -0.5, 0.5 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.5,0.5]
+								"offset": [ -0.5, 0.5 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [-0.5,0.5]
+								"offset": [ -0.5, 0.5 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.5,0.5]
+								"offset": [ -0.5, 0.5 ]
 							}
 						},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
 						"position-birthing": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						}
 					}
@@ -1850,49 +1850,49 @@
 			"actor2-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -1907,137 +1907,137 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [-0.125,-0.125]
+								"offset": [ -0.125, -0.125 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.125,-0.125]
+								"offset": [ -0.125, -0.125 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [-0.125,-0.125]
+								"offset": [ -0.125, -0.125 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.125,-0.125]
+								"offset": [ -0.125, -0.125 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0,-0.125]
+								"offset": [ 0, -0.125 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0,-0.125]
+								"offset": [ 0, -0.125 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0,-0.125]
+								"offset": [ 0, -0.125 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0,-0.125]
+								"offset": [ 0, -0.125 ]
 							}
 						},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
 						"position4": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position-birthing": {}
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2048,49 +2048,49 @@
 			"actor2-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2103,65 +2103,65 @@
 			"actor2-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
 						"position5": {
 							"frameProperties": {
-								"zLevel": [42,42,42,42,42]
+								"zLevel": [ 42, 42, 42, 42, 42 ]
 							}
 						},
 						"position5-climax": {
 							"frameProperties": {
-								"zLevel": [42]
+								"zLevel": [ 42 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
-								"zLevel": [42,42,42,42,42,42,42,42,42,42,42,42,42]
+								"zLevel": [ 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42 ]
 							}
 						},
 						"position5-reset": {
 							"frameProperties": {
-								"zLevel": [42]
+								"zLevel": [ 42 ]
 							}
 						},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2174,183 +2174,187 @@
 			"actor2-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
+						"idle_laying": {
+							"properties": {
+								"offset": [ 3, 1.375 ]
+							}
+						},
 						"idle": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position1": {
 							"properties": {
-								"offset": [2.875,1.375]
+								"offset": [ 2.875, 1.375 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [2.875,1.375]
+								"offset": [ 2.875, 1.375 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [2.875,1.375]
+								"offset": [ 2.875, 1.375 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [2.875,1.375]
+								"offset": [ 2.875, 1.375 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [2.25,0.875]
+								"offset": [ 2.25, 0.875 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [2.25,0.875]
+								"offset": [ 2.25, 0.875 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [2.25,0.875]
+								"offset": [ 2.25, 0.875 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [2.25,0.875]
+								"offset": [ 2.25, 0.875 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [2.75,1.5]
+								"offset": [ 2.75, 1.5 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [2.75,1.5]
+								"offset": [ 2.75, 1.5 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [2.75,1.5]
+								"offset": [ 2.75, 1.5 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [2.75,1.5]
+								"offset": [ 2.75, 1.5 ]
 							}
 						},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						}
 					}
@@ -2374,411 +2378,411 @@
 			"actor2-head": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": { },
+						"idle": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.25],
-									[0.25,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25]
+									[ 0.375, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.375,-0.25]
+								"offset": [ 0.375, -0.25 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.25]
+									[ 0.375, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.375,-0.25]
+								"offset": [ 0.375, -0.25 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.625,-1.5],
-									[0.75,-1.5],
-									[0.875,-1.375],
-									[1,-1.375],
-									[0.875,-1.5]
+									[ 0.625, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.875, -1.375 ],
+									[ 1, -1.375 ],
+									[ 0.875, -1.5 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.625,-1.5]
+								"offset": [ 0.625, -1.5 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.625,-1.5],
-									[0.75,-1.5],
-									[0.75,-1.5],
-									[0.875,-1.375],
-									[0.875,-1.375],
-									[0.875,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[0.875,-1.5],
-									[0.875,-1.5]
+									[ 0.625, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.875, -1.375 ],
+									[ 0.875, -1.375 ],
+									[ 0.875, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 0.875, -1.5 ],
+									[ 0.875, -1.5 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.625,-1.5]
+								"offset": [ 0.625, -1.5 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[1.25,-2],
-									[1.25,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2]
+									[ 1.25, -2 ],
+									[ 1.25, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [1.25,-2]
+								"offset": [ 1.25, -2 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[1.25,-2],
-									[1.25,-2],
-									[1.25,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2],
-									[1.125,-2]
+									[ 1.25, -2 ],
+									[ 1.25, -2 ],
+									[ 1.25, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ],
+									[ 1.125, -2 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [1.25,-2]
+								"offset": [ 1.25, -2 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[-0.25,0.125],
-									[-0.25,0.25],
-									[-0.125,0.375],
-									[-0.125,0.5],
-									[-0.125,0.375]
+									[ -0.25, 0.125 ],
+									[ -0.25, 0.25 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.375 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.25,0.125]
+								"offset": [ -0.25, 0.125 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.25,0.125],
-									[-0.25,0.25],
-									[-0.25,0.25],
-									[-0.125,0.375],
-									[-0.125,0.375],
-									[-0.125,0.375],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.375],
-									[-0.125,0.375]
+									[ -0.25, 0.125 ],
+									[ -0.25, 0.25 ],
+									[ -0.25, 0.25 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.25,0.125]
+								"offset": [ -0.25, 0.125 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position7": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position7-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position8": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position8-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [1.25,-2]
+								"offset": [ 1.25, -2 ]
 							}
 						}
 					}
@@ -2792,49 +2796,49 @@
 			"actor2-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2850,49 +2854,49 @@
 			"actor2-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2905,49 +2909,49 @@
 			"actor2-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -2960,49 +2964,49 @@
 			"actor2-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -3015,79 +3019,79 @@
 			"actor2-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
 					"anchorPart": "actor2-head",
 					"centered": false,
-					"offset": [2.875,2.875],
+					"offset": [ 2.875, 2.875 ],
 					"zLevel": 99
 				}
 			},
 			"actor2": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position2": {},
-						"position3": {},
-						"position4": {},
-						"position4_1": {},
-						"position4_2": {},
-						"position5": {},
-						"position6": {},
-						"position7": {},
-						"position8": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position2": { },
+						"position3": { },
+						"position4": { },
+						"position4_1": { },
+						"position4_2": { },
+						"position5": { },
+						"position6": { },
+						"position7": { },
+						"position8": { }
 					}
 				},
 				"properties": {
 					"centered": false,
 					"anchorPart": "actors",
-					"offset": [-2.75,0]
+					"offset": [ -2.75, 0 ]
 				}
 			},
 			"actor2-nipple1-inner": {
@@ -3102,377 +3106,377 @@
 					"actors": {
 						"idle": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"idle_laying": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-0.625],
-									[0.625,-0.375],
-									[0.5,-0.5],
-									[0.5,-0.625],
-									[0.5,-0.625]
+									[ 0.75, -0.625 ],
+									[ 0.625, -0.375 ],
+									[ 0.5, -0.5 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.75,-0.625]
+								"offset": [ 0.75, -0.625 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-0.625],
-									[0.625,-0.375],
-									[0.625,-0.375],
-									[0.5,-0.5],
-									[0.5,-0.5],
-									[0.5,-0.5],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625],
-									[0.5,-0.625]
+									[ 0.75, -0.625 ],
+									[ 0.625, -0.375 ],
+									[ 0.625, -0.375 ],
+									[ 0.5, -0.5 ],
+									[ 0.5, -0.5 ],
+									[ 0.5, -0.5 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.625 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.75,-0.625]
+								"offset": [ 0.75, -0.625 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.75],
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.25,-1.875],
-									[1.125,-1.875]
+									[ 1, -1.75 ],
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.125, -1.875 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.875,-2]
+								"offset": [ 0.875, -2 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.75],
-									[1,-1.875],
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875]
+									[ 1, -1.75 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.875,-2]
+								"offset": [ 0.875, -2 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875]
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875]
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.75],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.75],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.75],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[0.125,0],
-									[0.125,-0.125],
-									[0.25,-0.125],
-									[0.25,0],
-									[0.25,0]
+									[ 0.125, 0 ],
+									[ 0.125, -0.125 ],
+									[ 0.25, -0.125 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.125,-0.325]
+								"offset": [ 0.125, -0.325 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,0],
-									[0.125,-0.125],
-									[0.125,-0.125],
-									[0.25,-0.125],
-									[0.25,-0.125],
-									[0.25,-0.125],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0],
-									[0.25,0]
+									[ 0.125, 0 ],
+									[ 0.125, -0.125 ],
+									[ 0.125, -0.125 ],
+									[ 0.25, -0.125 ],
+									[ 0.25, -0.125 ],
+									[ 0.25, -0.125 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ],
+									[ 0.25, 0 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.125,-0.325]
+								"offset": [ 0.125, -0.325 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.625],
-									[-0.625,-1.625],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.625,-1.625]
+									[ -0.625, -1.625 ],
+									[ -0.625, -1.625 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.625, -1.625 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.625,-1.625]
+								"offset": [ -0.625, -1.625 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.625],
-									[-0.625,-1.625],
-									[-0.625,-1.625],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.625,-1.625],
-									[-0.625,-1.625]
+									[ -0.625, -1.625 ],
+									[ -0.625, -1.625 ],
+									[ -0.625, -1.625 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.625, -1.625 ],
+									[ -0.625, -1.625 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.625,-1.625]
+								"offset": [ -0.625, -1.625 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						}
 					}
@@ -3505,377 +3509,377 @@
 					"actors": {
 						"idle": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"idle_laying": {
 							"properties": {
-								"offset": [0.75,-1.875]
+								"offset": [ 0.75, -1.875 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.375,-0.375],
-									[0.25,-0.5],
-									[0.25,-0.625],
-									[0.25,-0.625]
+									[ 0.5, -0.625 ],
+									[ 0.375, -0.375 ],
+									[ 0.25, -0.5 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.5,-0.625]
+								"offset": [ 0.5, -0.625 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.25,-0.5],
-									[0.25,-0.5],
-									[0.25,-0.5],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625]
+									[ 0.5, -0.625 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.25, -0.5 ],
+									[ 0.25, -0.5 ],
+									[ 0.25, -0.5 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.5,-0.625]
+								"offset": [ 0.5, -0.625 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.75],
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[1,-1.875],
-									[0.875,-1.875]
+									[ 0.75, -1.75 ],
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 1, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.75],
-									[0.75,-1.875],
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875]
+									[ 0.75, -1.75 ],
+									[ 0.75, -1.875 ],
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.5,-1.875],
-									[0.625,-1.875]
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.625, -1.875 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.75,-1.875]
+								"offset": [ 0.75, -1.875 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.5,-1.875],
-									[0.5,-1.875],
-									[0.5,-1.875],
-									[0.5,-1.875],
-									[0.5,-1.875],
-									[0.625,-1.875],
-									[0.625,-1.875]
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.5, -1.875 ],
+									[ 0.625, -1.875 ],
+									[ 0.625, -1.875 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.75,-1.875]
+								"offset": [ 0.75, -1.875 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.75],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.75],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.75],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,-0.125],
-									[0,-0.125],
-									[0,0],
-									[0,0]
+									[ -0.125, 0 ],
+									[ -0.125, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, 0 ],
+									[ 0, 0 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.125,-0.325]
+								"offset": [ -0.125, -0.325 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,-0.125],
-									[-0.125,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,0],
-									[0,0],
-									[0,0],
-									[0,0],
-									[0,0],
-									[0,0],
-									[0,0]
+									[ -0.125, 0 ],
+									[ -0.125, -0.125 ],
+									[ -0.125, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.125,-0.325]
+								"offset": [ -0.125, -0.325 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.375,-1.625]
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.375, -1.625 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.375,-1.625]
+								"offset": [ -0.375, -1.625 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.375,-1.625],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.25,-1.5],
-									[-0.375,-1.625],
-									[-0.375,-1.625]
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.25, -1.5 ],
+									[ -0.375, -1.625 ],
+									[ -0.375, -1.625 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.375,-1.625]
+								"offset": [ -0.375, -1.625 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [0.75,-1.875]
+								"offset": [ 0.75, -1.875 ]
 							}
 						}
 					}
@@ -3899,72 +3903,72 @@
 			"actor1": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position2": {},
-						"position3": {},
-						"position4": {},
-						"position4_1": {},
-						"position4_2": {},
-						"position5": {},
-						"position6": {},
-						"position7": {},
-						"position8": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position2": { },
+						"position3": { },
+						"position4": { },
+						"position4_1": { },
+						"position4_2": { },
+						"position5": { },
+						"position6": { },
+						"position7": { },
+						"position8": { }
 					}
 				},
 				"properties": {
 					"centered": false,
 					"anchorPart": "actors",
-					"offset": [-2.75,0]
+					"offset": [ -2.75, 0 ]
 				}
 			},
 			"actor1-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -3977,49 +3981,49 @@
 			"actor1-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4032,49 +4036,49 @@
 			"actor1-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4089,217 +4093,217 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [0.5,0]
+								"offset": [ 0.5, 0 ]
 							}
 						},
 						"idle": {
 							"properties": {
-								"offset": [1.5,0]
+								"offset": [ 1.5, 0 ]
 							}
 						},
 						"position1": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [-0.875,0]
+								"offset": [ -0.875, 0 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.875,0]
+								"offset": [ -0.875, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [-0.875,0]
+								"offset": [ -0.875, 0 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.875,0]
+								"offset": [ -0.875, 0 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [-1.125,0]
+								"offset": [ -1.125, 0 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [-1.125,0]
+								"offset": [ -1.125, 0 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [-1.125,0]
+								"offset": [ -1.125, 0 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [-1.125,0]
+								"offset": [ -1.125, 0 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.5,0]
+								"offset": [ -0.5, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0.625,0]
+								"offset": [ 0.625, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -4319,157 +4323,157 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [3,1.25]
+								"offset": [ 3, 1.25 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [3,1.25]
+								"offset": [ 3, 1.25 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [3,1.25]
+								"offset": [ 3, 1.25 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [3.125,0.875]
+								"offset": [ 3.125, 0.875 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [3.125,0.875]
+								"offset": [ 3.125, 0.875 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [3.125,0.875]
+								"offset": [ 3.125, 0.875 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [3.375,0.625]
+								"offset": [ 3.375, 0.625 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [3.375,0.625]
+								"offset": [ 3.375, 0.625 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [3.375,0.625]
+								"offset": [ 3.375, 0.625 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [2.75,0.75]
+								"offset": [ 2.75, 0.75 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [2.75,0.75]
+								"offset": [ 2.75, 0.75 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [2.75,0.75]
+								"offset": [ 2.75, 0.75 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [2.75,0.75]
+								"offset": [ 2.75, 0.75 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [2.75,0.75]
+								"offset": [ 2.75, 0.75 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [2.75,0.75]
+								"offset": [ 2.75, 0.75 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [2.875,1.25]
+								"offset": [ 2.875, 1.25 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						}
 					}
@@ -4482,49 +4486,49 @@
 			"actor1-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4537,54 +4541,54 @@
 			"actor1-climax-with-vagina": {
 				"partStates": {
 					"actors": {
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
 						"position5": {
 							"properties": {
-								"offset": [0,-0.25]
+								"offset": [ 0, -0.25 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,-0.25]
+								"offset": [ 0, -0.25 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,-0.25]
+								"offset": [ 0, -0.25 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,-0.25]
+								"offset": [ 0, -0.25 ]
 							}
 						},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position-birthing": {}
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4597,157 +4601,157 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [2.75,1.375]
+								"offset": [ 2.75, 1.375 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [2.75,1.375]
+								"offset": [ 2.75, 1.375 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [2.75,1.375]
+								"offset": [ 2.75, 1.375 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [2.75,0.875]
+								"offset": [ 2.75, 0.875 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [2.75,0.875]
+								"offset": [ 2.75, 0.875 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [2.75,0.875]
+								"offset": [ 2.75, 0.875 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [3.825,1]
+								"offset": [ 3.825, 1 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [3.825,1]
+								"offset": [ 3.825, 1 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [3.825,1]
+								"offset": [ 3.825, 1 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						}
 					}
@@ -4762,122 +4766,122 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.625,0]
+								"offset": [ -0.625, 0 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
 						"position4_2": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,-0.375]
+								"offset": [ 0, -0.375 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,-0.375]
+								"offset": [ 0, -0.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,-0.375]
+								"offset": [ 0, -0.375 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,-0.375]
+								"offset": [ 0, -0.375 ]
 							}
 						},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
 						"position-birthing": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						}
 					}
@@ -4890,49 +4894,49 @@
 			"actor1-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -4945,183 +4949,187 @@
 			"actor1-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
+						"idle_laying": {
+							"properties": {
+								"offset": [ 3, 1.375 ]
+							}
+						},
 						"idle": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position1": {
 							"properties": {
-								"offset": [3.125,1.375]
+								"offset": [ 3.125, 1.375 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [3.125,1.375]
+								"offset": [ 3.125, 1.375 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [3.125,1.375]
+								"offset": [ 3.125, 1.375 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [3.125,1.375]
+								"offset": [ 3.125, 1.375 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [3,1.375]
+								"offset": [ 3, 1.375 ]
 							}
 						},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						}
 					}
@@ -5134,49 +5142,49 @@
 			"actor1-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -5202,353 +5210,353 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
-						"idle": {},
+						"idle": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,0],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125]
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,0],
-									[-0.125,0],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125]
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375]
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.125,-0.375]
+								"offset": [ -0.125, -0.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375]
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.125,-0.375]
+								"offset": [ -0.125, -0.375 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.5],
-									[0.375,-0.625]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.25,-0.625]
+								"offset": [ 0.25, -0.625 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.25,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.25,-0.625]
+								"offset": [ 0.25, -0.625 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.125,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.0,-2],
-									[-1.125,-2],
-									[-1.125,-2]
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.0, -2 ],
+									[ -1.125, -2 ],
+									[ -1.125, -2 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-1.125,-2]
+								"offset": [ -1.125, -2 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[0,0],
-									[0,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0]
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,0],
-									[0,0],
-									[0,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0],
-									[0.125,0]
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ],
+									[ 0.125, 0 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [1.25,-2]
+								"offset": [ 1.25, -2 ]
 							}
 						}
 					}
@@ -5562,49 +5570,49 @@
 			"actor1-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -5620,49 +5628,49 @@
 			"actor1-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -5675,49 +5683,49 @@
 			"actor1-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -5730,104 +5738,104 @@
 			"actor1-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
 					"anchorPart": "actor1-head",
 					"centered": false,
-					"offset": [2.875,2.875],
+					"offset": [ 2.875, 2.875 ],
 					"zLevel": 99
 				}
 			},
 			"actor1-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -5876,377 +5884,377 @@
 					"actors": {
 						"idle": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"idle_laying": {
 							"properties": {
-								"offset": [0.75,-0.825]
+								"offset": [ 0.75, -0.825 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.25],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.5,-0.375]
+								"offset": [ 0.5, -0.375 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.25],
-									[0.375,-0.25],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.5,-0.375]
+								"offset": [ 0.5, -0.375 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.75],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.75]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.75 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.5,-0.75]
+								"offset": [ 0.5, -0.75 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.75],
-									[0.5,-0.75],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.75],
-									[0.5,-0.75]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.75 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.5,-0.75]
+								"offset": [ 0.5, -0.75 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-0.825],
-									[0.75,-1],
-									[0.75,-1.125],
-									[0.625,-1],
-									[0.75,-1.125]
+									[ 0.75, -0.825 ],
+									[ 0.75, -1 ],
+									[ 0.75, -1.125 ],
+									[ 0.625, -1 ],
+									[ 0.75, -1.125 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.75,-1]
+								"offset": [ 0.75, -1 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-0.825],
-									[0.75,-1],
-									[0.75,-1],
-									[0.75,-1.125],
-									[0.75,-1.125],
-									[0.75,-1.125],
-									[0.625,-1],
-									[0.625,-1],
-									[0.625,-1],
-									[0.625,-1],
-									[0.625,-1],
-									[0.75,-1.125],
-									[0.75,-1.125]
+									[ 0.75, -0.825 ],
+									[ 0.75, -1 ],
+									[ 0.75, -1 ],
+									[ 0.75, -1.125 ],
+									[ 0.75, -1.125 ],
+									[ 0.75, -1.125 ],
+									[ 0.625, -1 ],
+									[ 0.625, -1 ],
+									[ 0.625, -1 ],
+									[ 0.625, -1 ],
+									[ 0.625, -1 ],
+									[ 0.75, -1.125 ],
+									[ 0.75, -1.125 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.75,-1]
+								"offset": [ 0.75, -1 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-1,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-1.125,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875]
+									[ -1, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -1.125, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-1,-1.875]
+								"offset": [ -1, -1.875 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375],
-									[0.375,-0.375]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.375 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0.375,-0.375]
+								"offset": [ 0.375, -0.375 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						}
 					}
@@ -6260,67 +6268,67 @@
 			"actor3": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position2": {},
-						"position3": {},
-						"position4": {},
-						"position4_1": {},
-						"position5": {},
-						"position6": {},
-						"position7": {},
-						"position8": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position2": { },
+						"position3": { },
+						"position4": { },
+						"position4_1": { },
+						"position5": { },
+						"position6": { },
+						"position7": { },
+						"position8": { }
 					}
 				},
 				"properties": {
 					"centered": false,
 					"anchorPart": "actors",
-					"offset": [-2.75,0]
+					"offset": [ -2.75, 0 ]
 				}
 			},
 			"actor3-arm-back": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6333,49 +6341,49 @@
 			"actor1-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6388,45 +6396,45 @@
 			"actor3-backwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6441,205 +6449,205 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [-1.5,0]
+								"offset": [ -1.5, 0 ]
 							}
 						},
 						"idle": {
 							"properties": {
-								"offset": [0.125,0]
+								"offset": [ 0.125, 0 ]
 							}
 						},
 						"position1": {
 							"properties": {
-								"offset": [-1.75,0],
+								"offset": [ -1.75, 0 ],
 								"zLevel": 31
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [-1.75,0],
+								"offset": [ -1.75, 0 ],
 								"zLevel": 31
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [-1.75,0],
+								"offset": [ -1.75, 0 ],
 								"zLevel": 31
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [-1.75,0],
+								"offset": [ -1.75, 0 ],
 								"zLevel": 31
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [-1.5,-0.125],
+								"offset": [ -1.5, -0.125 ],
 								"zLevel": 23
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [-1.5,-0.125],
+								"offset": [ -1.5, -0.125 ],
 								"zLevel": 23
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [-1.5,-0.125],
+								"offset": [ -1.5, -0.125 ],
 								"zLevel": 23
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [-1.5,-0.125],
+								"offset": [ -1.5, -0.125 ],
 								"zLevel": 23
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [1,0]
+								"offset": [ 1, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [1,0]
+								"offset": [ 1, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [1,0]
+								"offset": [ 1, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [1,0]
+								"offset": [ 1, 0 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.25,0]
+								"offset": [ -0.25, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0.75,0]
+								"offset": [ 0.75, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					}
@@ -6657,45 +6665,45 @@
 			"actor3-bsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -6710,377 +6718,377 @@
 					"actors": {
 						"idle": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"idle_laying": {
 							"properties": {
-								"offset": [0.5,-0.825]
+								"offset": [ 0.5, -0.825 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.25],
-									[0.125,-0.5],
-									[0.125,-0.625],
-									[0.125,-0.625]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.25,-0.375]
+								"offset": [ 0.25, -0.375 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.25,-0.375]
+								"offset": [ 0.25, -0.375 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.75],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.75]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.75 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.25,-0.75]
+								"offset": [ 0.25, -0.75 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.75],
-									[0.25,-0.75],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.75],
-									[0.25,-0.75]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.75 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.25,-0.75]
+								"offset": [ 0.25, -0.75 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.825],
-									[0.5,-1],
-									[0.5,-1.125],
-									[0.375,-1],
-									[0.5,-1.125]
+									[ 0.5, -0.825 ],
+									[ 0.5, -1 ],
+									[ 0.5, -1.125 ],
+									[ 0.375, -1 ],
+									[ 0.5, -1.125 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.5,-1]
+								"offset": [ 0.5, -1 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.825],
-									[0.5,-1],
-									[0.5,-1],
-									[0.5,-1.125],
-									[0.5,-1.125],
-									[0.5,-1.125],
-									[0.375,-1],
-									[0.375,-1],
-									[0.375,-1],
-									[0.375,-1],
-									[0.375,-1],
-									[0.5,-1.125],
-									[0.5,-1.125]
+									[ 0.5, -0.825 ],
+									[ 0.5, -1 ],
+									[ 0.5, -1 ],
+									[ 0.5, -1.125 ],
+									[ 0.5, -1.125 ],
+									[ 0.5, -1.125 ],
+									[ 0.375, -1 ],
+									[ 0.375, -1 ],
+									[ 0.375, -1 ],
+									[ 0.375, -1 ],
+									[ 0.375, -1 ],
+									[ 0.5, -1.125 ],
+									[ 0.5, -1.125 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.5,-1]
+								"offset": [ 0.5, -1 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4_2": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.75,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.875,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.5,-1.875],
-									[-0.625,-1.875],
-									[-0.625,-1.875]
+									[ -0.75, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.875, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.5, -1.875 ],
+									[ -0.625, -1.875 ],
+									[ -0.625, -1.875 ]
 								]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [-0.75,-1.875]
+								"offset": [ -0.75, -1.875 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.125,-0.375]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0.125,-0.375]
+								"offset": [ 0.125, -0.375 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [0.75,-1.875]
+								"offset": [ 0.75, -1.875 ]
 							}
 						}
 					}
@@ -7094,45 +7102,45 @@
 			"actor3-chestwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7145,74 +7153,74 @@
 			"actor3-climax-with-penis": {
 				"partStates": {
 					"actors": {
-						"position1": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
+						"position1": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
 						"position4": {
 							"properties": {
-								"offset": [-1,0]
+								"offset": [ -1, 0 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-1,0]
+								"offset": [ -1, 0 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [-1,0]
+								"offset": [ -1, 0 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-1,0]
+								"offset": [ -1, 0 ]
 							}
 						},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
 						"position4_2": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
 						"position-birthing": {
 							"properties": {
-								"offset": [0,0.5]
+								"offset": [ 0, 0.5 ]
 							}
 						}
 					}
@@ -7227,142 +7235,142 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [2.75,1.25]
+								"offset": [ 2.75, 1.25 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [2.75,1.25]
+								"offset": [ 2.75, 1.25 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [2.75,1.25]
+								"offset": [ 2.75, 1.25 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [2.125,0.5]
+								"offset": [ 2.125, 0.5 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [2.125,0.5]
+								"offset": [ 2.125, 0.5 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [2.125,0.5]
+								"offset": [ 2.125, 0.5 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [2.5,0.825]
+								"offset": [ 2.5, 0.825 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [2.625,1.375]
+								"offset": [ 2.625, 1.375 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [2.625,1.375]
+								"offset": [ 2.625, 1.375 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [2.625,1.375]
+								"offset": [ 2.625, 1.375 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [2.625,0.5]
+								"offset": [ 2.625, 0.5 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [2.625,1]
+								"offset": [ 2.625, 1 ]
 							}
 						}
 					}
@@ -7375,45 +7383,45 @@
 			"actor3-arm-front": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7426,37 +7434,37 @@
 			"actor3-climax-with-vagina": {
 				"partStates": {
 					"actors": {
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position-birthing": {}
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7467,45 +7475,45 @@
 			"actor3-fsleeve": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7529,111 +7537,119 @@
 			"actor3-groin-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": {
+							"properties": {
+								"offset": [ 3, 1.375 ]
+							}
+						},
+						"idle": {
+							"properties": {
+								"offset": [ 3, 1.375 ]
+							}
+						},
 						"position1": {
 							"properties": {
-								"offset": [2.25,0.875]
+								"offset": [ 2.25, 0.875 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [2.25,0.875]
+								"offset": [ 2.25, 0.875 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [2.25,0.875]
+								"offset": [ 2.25, 0.875 ]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [2.25,0.875]
+								"offset": [ 2.25, 0.875 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [3.125,1.375]
+								"offset": [ 3.125, 1.375 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [3.125,1.375]
+								"offset": [ 3.125, 1.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [3.125,1.375]
+								"offset": [ 3.125, 1.375 ]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [3.125,1.375]
+								"offset": [ 3.125, 1.375 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [2.825,0.825]
+								"offset": [ 2.825, 0.825 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
 						"position-birthing": {
 							"properties": {
-								"offset": [3.5,0.75]
+								"offset": [ 3.5, 0.75 ]
 							}
 						}
 					}
@@ -7646,45 +7662,45 @@
 			"actor3-groin": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -7697,371 +7713,371 @@
 			"actor3-head": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
+						"idle_laying": { },
+						"idle": { },
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.625,-1.5],
-									[0.75,-1.5],
-									[0.875,-1.375],
-									[1,-1.375],
-									[0.875,-1.5]
+									[ 0.625, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.875, -1.375 ],
+									[ 1, -1.375 ],
+									[ 0.875, -1.5 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.625,-1.5]
+								"offset": [ 0.625, -1.5 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.625,-1.5],
-									[0.75,-1.5],
-									[0.75,-1.5],
-									[0.875,-1.375],
-									[0.875,-1.375],
-									[0.875,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[1,-1.375],
-									[0.875,-1.5],
-									[0.875,-1.5]
+									[ 0.625, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.75, -1.5 ],
+									[ 0.875, -1.375 ],
+									[ 0.875, -1.375 ],
+									[ 0.875, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 1, -1.375 ],
+									[ 0.875, -1.5 ],
+									[ 0.875, -1.5 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.625,-1.5]
+								"offset": [ 0.625, -1.5 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,0],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125]
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,0],
-									[-0.125,0],
-									[-0.125,0],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125],
-									[0,-0.125]
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ -0.125, 0 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ],
+									[ 0, -0.125 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [-0.125,0]
+								"offset": [ -0.125, 0 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375]
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [-0.125,-0.375]
+								"offset": [ -0.125, -0.375 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[-0.125,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375],
-									[0,-0.375]
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ -0.125, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ],
+									[ 0, -0.375 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [-0.125,-0.375]
+								"offset": [ -0.125, -0.375 ]
 							}
 						},
 						"position4_1": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.5],
-									[0.125,-0.375],
-									[0.125,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.375],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.25],
-									[0.25,-0.375],
-									[0.25,-0.375]
+									[ 0.25, -0.5 ],
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.25 ],
+									[ 0.25, -0.375 ],
+									[ 0.25, -0.375 ]
 								]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0.25,-0.5]
+								"offset": [ 0.25, -0.5 ]
 							}
 						},
 						"position5": {
 							"frameProperties": {
 								"offset": [
-									[-0.25,0.125],
-									[-0.25,0.25],
-									[-0.125,0.375],
-									[-0.125,0.5],
-									[-0.125,0.375]
+									[ -0.25, 0.125 ],
+									[ -0.25, 0.25 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.375 ]
 								]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [-0.25,0.125]
+								"offset": [ -0.25, 0.125 ]
 							}
 						},
 						"position5-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.25,0.125],
-									[-0.25,0.25],
-									[-0.25,0.25],
-									[-0.125,0.375],
-									[-0.125,0.375],
-									[-0.125,0.375],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.5],
-									[-0.125,0.375],
-									[-0.125,0.375]
+									[ -0.25, 0.125 ],
+									[ -0.25, 0.25 ],
+									[ -0.25, 0.25 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.5 ],
+									[ -0.125, 0.375 ],
+									[ -0.125, 0.375 ]
 								]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [-0.25,0.125]
+								"offset": [ -0.25, 0.125 ]
 							}
 						},
 						"position6": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position6-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position7": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position7-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position8": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position8-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.625,-1.5],
-									[-0.5,-1.5],
-									[-0.5,-1.5],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.375,-1.375],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.25,-1.25],
-									[-0.5,-1.5],
-									[-0.5,-1.5]
+									[ -0.625, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.375, -1.375 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.25, -1.25 ],
+									[ -0.5, -1.5 ],
+									[ -0.5, -1.5 ]
 								]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [-0.625,-1.5]
+								"offset": [ -0.625, -1.5 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [1.25,-2]
+								"offset": [ 1.25, -2 ]
 							}
 						}
 					}
@@ -8075,45 +8091,45 @@
 			"actor3-head-inner": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8129,45 +8145,45 @@
 			"actor3-headwear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8180,49 +8196,49 @@
 			"actor3-headwear-static": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position4_2": {},
-						"position4_2-climax": {},
-						"position4_2-postclimax": {},
-						"position4_2-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position4_2": { },
+						"position4_2-climax": { },
+						"position4_2-postclimax": { },
+						"position4_2-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8235,45 +8251,45 @@
 			"actor3-legswear": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
@@ -8286,51 +8302,51 @@
 			"actor3-mouth": {
 				"partStates": {
 					"actors": {
-						"idle_laying": {},
-						"idle": {},
-						"position1": {},
-						"position1-climax": {},
-						"position1-postclimax": {},
-						"position1-reset": {},
-						"position2": {},
-						"position2-climax": {},
-						"position2-postclimax": {},
-						"position2-reset": {},
-						"position3": {},
-						"position3-climax": {},
-						"position3-postclimax": {},
-						"position3-reset": {},
-						"position4": {},
-						"position4-climax": {},
-						"position4-postclimax": {},
-						"position4-reset": {},
-						"position4_1": {},
-						"position4_1-climax": {},
-						"position4_1-postclimax": {},
-						"position4_1-reset": {},
-						"position5": {},
-						"position5-climax": {},
-						"position5-postclimax": {},
-						"position5-reset": {},
-						"position6": {},
-						"position6-climax": {},
-						"position6-postclimax": {},
-						"position6-reset": {},
-						"position7": {},
-						"position7-climax": {},
-						"position7-postclimax": {},
-						"position7-reset": {},
-						"position8": {},
-						"position8-climax": {},
-						"position8-postclimax": {},
-						"position8-reset": {},
-						"position-birthing": {}
+						"idle_laying": { },
+						"idle": { },
+						"position1": { },
+						"position1-climax": { },
+						"position1-postclimax": { },
+						"position1-reset": { },
+						"position2": { },
+						"position2-climax": { },
+						"position2-postclimax": { },
+						"position2-reset": { },
+						"position3": { },
+						"position3-climax": { },
+						"position3-postclimax": { },
+						"position3-reset": { },
+						"position4": { },
+						"position4-climax": { },
+						"position4-postclimax": { },
+						"position4-reset": { },
+						"position4_1": { },
+						"position4_1-climax": { },
+						"position4_1-postclimax": { },
+						"position4_1-reset": { },
+						"position5": { },
+						"position5-climax": { },
+						"position5-postclimax": { },
+						"position5-reset": { },
+						"position6": { },
+						"position6-climax": { },
+						"position6-postclimax": { },
+						"position6-reset": { },
+						"position7": { },
+						"position7-climax": { },
+						"position7-postclimax": { },
+						"position7-reset": { },
+						"position8": { },
+						"position8-climax": { },
+						"position8-postclimax": { },
+						"position8-reset": { },
+						"position-birthing": { }
 					}
 				},
 				"properties": {
 					"anchorPart": "actor3-head",
 					"centered": false,
-					"offset": [2.875,2.875],
+					"offset": [ 2.875, 2.875 ],
 					"zLevel": 99
 				}
 			},
@@ -8346,295 +8362,295 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.75],
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[1,-1.875],
-									[0.875,-1.875]
+									[ 0.75, -1.75 ],
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 1, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.75,-1.75],
-									[0.75,-1.875],
-									[0.75,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[1,-1.875],
-									[0.875,-1.875],
-									[0.875,-1.875]
+									[ 0.75, -1.75 ],
+									[ 0.75, -1.875 ],
+									[ 0.75, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 0.875, -1.875 ],
+									[ 0.875, -1.875 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.625,-2]
+								"offset": [ 0.625, -2 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.25],
-									[0.125,-0.5],
-									[0.125,-0.625],
-									[0.125,-0.625]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.25,-0.375]
+								"offset": [ 0.25, -0.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.125,-0.375],
-									[0.125,-0.25],
-									[0.125,-0.25],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.5],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625],
-									[0.125,-0.625]
+									[ 0.125, -0.375 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.25 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.5 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ],
+									[ 0.125, -0.625 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.25,-0.375]
+								"offset": [ 0.25, -0.375 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0,-1],
-									[-0.125,-0.875],
-									[-0.125,-0.875],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.75],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.625],
-									[0,-0.75],
-									[0,-0.75]
+									[ 0, -1 ],
+									[ -0.125, -0.875 ],
+									[ -0.125, -0.875 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.625 ],
+									[ 0, -0.75 ],
+									[ 0, -0.75 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [0,-1]
+								"offset": [ 0, -1 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.75],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.75]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.25,-0.75]
+								"offset": [ 0.25, -0.75 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.25,-0.625],
-									[0.25,-0.75],
-									[0.25,-0.75],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.825],
-									[0.25,-0.75],
-									[0.25,-0.75]
+									[ 0.25, -0.625 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.825 ],
+									[ 0.25, -0.75 ],
+									[ 0.25, -0.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.25,-0.75]
+								"offset": [ 0.25, -0.75 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						}
 					},
 					"position-birthing": {
-							"properties": {
-								"offset": [0.75,-1.875]
-							}
+						"properties": {
+							"offset": [ 0.75, -1.875 ]
 						}
+					}
 				},
 				"properties": {
 					"anchorPart": "actor3-body",
@@ -8646,292 +8662,292 @@
 					"actors": {
 						"idle_laying": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position1": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.75],
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.25,-1.875],
-									[1.125,-1.875]
+									[ 1, -1.75 ],
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.125, -1.875 ]
 								]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [0.875,-2]
+								"offset": [ 0.875, -2 ]
 							}
 						},
 						"position1-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[1,-1.75],
-									[1,-1.875],
-									[1,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.25,-1.875],
-									[1.125,-1.875],
-									[1.125,-1.875]
+									[ 1, -1.75 ],
+									[ 1, -1.875 ],
+									[ 1, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.25, -1.875 ],
+									[ 1.125, -1.875 ],
+									[ 1.125, -1.875 ]
 								]
 							}
 						},
 						"position1-reset": {
 							"properties": {
-								"offset": [0.875,-2]
+								"offset": [ 0.875, -2 ]
 							}
 						},
 						"position2": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.25],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [0.5,-0.375]
+								"offset": [ 0.5, -0.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.375,-0.375],
-									[0.375,-0.25],
-									[0.375,-0.25],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.5],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625],
-									[0.375,-0.625]
+									[ 0.375, -0.375 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.25 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.5 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ],
+									[ 0.375, -0.625 ]
 								]
 							}
 						},
 						"position2-reset": {
 							"properties": {
-								"offset": [0.5,-0.375]
+								"offset": [ 0.5, -0.375 ]
 							}
 						},
 						"position3": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position3-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[-0.325,-1],
-									[-0.5,-0.875],
-									[-0.5,-0.875],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.75],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.625],
-									[-0.325,-0.75],
-									[-0.325,-0.75]
+									[ -0.325, -1 ],
+									[ -0.5, -0.875 ],
+									[ -0.5, -0.875 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.625 ],
+									[ -0.325, -0.75 ],
+									[ -0.325, -0.75 ]
 								]
 							}
 						},
 						"position3-reset": {
 							"properties": {
-								"offset": [-0.325,-1]
+								"offset": [ -0.325, -1 ]
 							}
 						},
 						"position4": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.75],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.75]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.75 ]
 								]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [0.5,-0.75]
+								"offset": [ 0.5, -0.75 ]
 							}
 						},
 						"position4-postclimax": {
 							"frameProperties": {
 								"offset": [
-									[0.5,-0.625],
-									[0.5,-0.75],
-									[0.5,-0.75],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.825],
-									[0.5,-0.75],
-									[0.5,-0.75]
+									[ 0.5, -0.625 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.825 ],
+									[ 0.5, -0.75 ],
+									[ 0.5, -0.75 ]
 								]
 							}
 						},
 						"position4-reset": {
 							"properties": {
-								"offset": [0.5,-0.75]
+								"offset": [ 0.5, -0.75 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_1-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_2": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_2-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_2-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position4_2-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position5-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position6-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position7-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position8-reset": {
 							"properties": {
-								"offset": [0,0]
+								"offset": [ 0, 0 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [1,-1.875]
+								"offset": [ 1, -1.875 ]
 							}
 						}
 					}
@@ -8973,142 +8989,142 @@
 					"actors": {
 						"position1": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position1-climax": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position1-postclimax": {
 							"properties": {
-								"offset": [3.25,1]
+								"offset": [ 3.25, 1 ]
 							}
 						},
 						"position2": {
 							"properties": {
-								"offset": [2.75,0.375]
+								"offset": [ 2.75, 0.375 ]
 							}
 						},
 						"position2-climax": {
 							"properties": {
-								"offset": [2.75,0.375]
+								"offset": [ 2.75, 0.375 ]
 							}
 						},
 						"position2-postclimax": {
 							"properties": {
-								"offset": [2.75,0.375]
+								"offset": [ 2.75, 0.375 ]
 							}
 						},
 						"position3": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						},
 						"position3-climax": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						},
 						"position3-postclimax": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						},
 						"position4": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position4-climax": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position4-postclimax": {
 							"properties": {
-								"offset": [2,0.825]
+								"offset": [ 2, 0.825 ]
 							}
 						},
 						"position4_1": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position4_1-climax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position4_1-postclimax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position5": {
 							"properties": {
-								"offset": [3.125,2.125]
+								"offset": [ 3.125, 2.125 ]
 							}
 						},
 						"position5-climax": {
 							"properties": {
-								"offset": [3.125,2.125]
+								"offset": [ 3.125, 2.125 ]
 							}
 						},
 						"position5-postclimax": {
 							"properties": {
-								"offset": [3.125,2.125]
+								"offset": [ 3.125, 2.125 ]
 							}
 						},
 						"position6": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position6-climax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position6-postclimax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position7": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position7-climax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position7-postclimax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position8": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position8-climax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position8-postclimax": {
 							"properties": {
-								"offset": [2.375,1]
+								"offset": [ 2.375, 1 ]
 							}
 						},
 						"position-birthing": {
 							"properties": {
-								"offset": [2.75,1.625]
+								"offset": [ 2.75, 1.625 ]
 							}
 						}
 					}
@@ -9458,7 +9474,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position1-climax": {
@@ -9472,7 +9488,7 @@
 						"mode": "transition",
 						"transition": "position1",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position1-reset": {
@@ -9485,7 +9501,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position2-climax": {
@@ -9499,7 +9515,7 @@
 						"mode": "transition",
 						"transition": "position2",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position2-reset": {
@@ -9512,7 +9528,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position3-climax": {
@@ -9526,7 +9542,7 @@
 						"mode": "transition",
 						"transition": "position3",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position3-reset": {
@@ -9539,7 +9555,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4-climax": {
@@ -9553,7 +9569,7 @@
 						"mode": "transition",
 						"transition": "position4",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4-reset": {
@@ -9566,7 +9582,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4_1-climax": {
@@ -9580,7 +9596,7 @@
 						"mode": "transition",
 						"transition": "position4_1",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4_1-reset": {
@@ -9593,7 +9609,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4_2-climax": {
@@ -9607,7 +9623,7 @@
 						"mode": "transition",
 						"transition": "position4_2",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position4_2-reset": {
@@ -9620,7 +9636,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position5-climax": {
@@ -9634,7 +9650,7 @@
 						"mode": "transition",
 						"transition": "position5",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position5-reset": {
@@ -9647,7 +9663,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position6-climax": {
@@ -9661,7 +9677,7 @@
 						"mode": "transition",
 						"transition": "position6",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position6-reset": {
@@ -9674,7 +9690,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position7-climax": {
@@ -9688,7 +9704,7 @@
 						"mode": "transition",
 						"transition": "position7",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position7-reset": {
@@ -9701,7 +9717,7 @@
 						"cycle": 1,
 						"mode": "loop",
 						"frameProperties": {
-							"immediateSound": ["/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position8-climax": {
@@ -9715,7 +9731,7 @@
 						"mode": "transition",
 						"transition": "position8",
 						"frameProperties": {
-							"immediateSound": ["","","/sfx/sexbound/thrusts/splat.ogg"]
+							"immediateSound": [ "", "", "/sfx/sexbound/thrusts/splat.ogg" ]
 						}
 					},
 					"position8-reset": {
@@ -9728,7 +9744,7 @@
 						"cycle": 1,
 						"mode": "loop"
 					},
-					"none": {}
+					"none": { }
 				},
 				"default": "none",
 				"properties": {
@@ -9962,7 +9978,7 @@
 						"cycle": 1,
 						"mode": "loop"
 					},
-					"none": {}
+					"none": { }
 				},
 				"default": "idle",
 				"properties": {
@@ -9979,9 +9995,9 @@
 					"particle": {
 						"type": "animated",
 						"animation": "/animations/emotes/happy.animation",
-						"position": [0,0],
-						"finalVelocity": [0,0],
-						"initialVelocity": [0,0],
+						"position": [ 0, 0 ],
+						"finalVelocity": [ 0, 0 ],
+						"initialVelocity": [ 0, 0 ],
 						"destructionTime": 0.2,
 						"destructionAction": "shrink",
 						"layer": "front",
@@ -9995,394 +10011,415 @@
 			"anchorPart": "actor2-nipple1",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor2-lactation-spew1": {
 			"anchorPart": "actor2-nipple1",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"actor2-lactation-drip2": {
 			"anchorPart": "actor2-nipple2",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor2-lactation-spew2": {
 			"anchorPart": "actor2-nipple2",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"climaxbutterflymale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflymale2"}
+				{ "particle": "climaxbutterflymale2" }
 			]
 		},
 		"climaxbutterflyfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflyfemale2"}
+				{ "particle": "climaxbutterflyfemale2" }
 			]
 		},
 		"climaxcowgirlmale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlmale2"}
+				{ "particle": "climaxcowgirlmale2" }
 			]
 		},
 		"climaxcowgirlfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlfemale2"}
+				{ "particle": "climaxcowgirlfemale2" }
 			]
 		},
 		"climaxdoggymale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale2"}
+				{ "particle": "climaxdoggymale2" }
 			]
 		},
 		"climaxdoubledoggymale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale2"}
+				{ "particle": "climaxdoggymale2" }
 			]
 		},
 		"climaxdoggyfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale2"}
+				{ "particle": "climaxdoggyfemale2" }
 			]
 		},
 		"climaxdoubledoggyfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale2"}
+				{ "particle": "climaxdoggyfemale2" }
 			]
 		},
 		"climaxfellatiomale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiomale2"}
+				{ "particle": "climaxfellatiomale2" }
 			]
 		},
 		"climaxfellatiofemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiofemale2"}
+				{ "particle": "climaxfellatiofemale2" }
 			]
 		},
 		"climaxmissionarymale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionarymale2"}
+				{ "particle": "climaxmissionarymale2" }
 			]
 		},
 		"climaxmissionaryfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionaryfemale2"}
+				{ "particle": "climaxmissionaryfemale2" }
 			]
 		},
 		"climaxstandingmale2": {
 			"anchorPart": "actor2-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingmale2"}
+				{ "particle": "climaxstandingmale2" }
 			]
 		},
 		"climaxstandingfemale2": {
 			"anchorPart": "actor2-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingfemale2"}
+				{ "particle": "climaxstandingfemale2" }
 			]
 		},
 		"actor1-lactation-drip1": {
 			"anchorPart": "actor1-nipple1",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor1-lactation-spew1": {
 			"anchorPart": "actor1-nipple1",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"actor1-lactation-drip2": {
 			"anchorPart": "actor1-nipple2",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor1-lactation-spew2": {
 			"anchorPart": "actor1-nipple2",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"climaxbutterflymale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflymale1"}
+				{ "particle": "climaxbutterflymale1" }
 			]
 		},
 		"climaxbutterflyfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflyfemale1"}
+				{ "particle": "climaxbutterflyfemale1" }
 			]
 		},
 		"climaxcowgirlmale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlmale1"}
+				{ "particle": "climaxcowgirlmale1" }
 			]
 		},
 		"climaxcowgirlfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlfemale1"}
+				{ "particle": "climaxcowgirlfemale1" }
 			]
 		},
 		"climaxdoggymale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale1"}
+				{ "particle": "climaxdoggymale1" }
 			]
 		},
 		"climaxdoubledoggymale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale2"}
+				{ "particle": "climaxdoggymale2" }
 			]
 		},
 		"climaxdoggyfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale1"}
+				{ "particle": "climaxdoggyfemale1" }
 			]
 		},
 		"climaxdoubledoggyfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale2"}
+				{ "particle": "climaxdoggyfemale2" }
+			]
+		},
+		"insemination-drip1": {
+			"anchorPart": "actor1-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
+			]
+		},
+		"insemination-drip2": {
+			"anchorPart": "actor2-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
+			]
+		},
+		"insemination-drip3": {
+			"anchorPart": "actor3-groin-inner",
+			"burstCount": 10,
+			"particles": [
+				{ "particle": "climaxfellatiomale1" }
 			]
 		},
 		"climaxfellatiomale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiomale1"}
+				{ "particle": "climaxfellatiomale1" }
 			]
 		},
 		"climaxfellatiofemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiofemale1"}
+				{ "particle": "climaxfellatiofemale1" }
 			]
 		},
 		"climaxmissionarymale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionarymale1"}
+				{ "particle": "climaxmissionarymale1" }
 			]
 		},
 		"climaxmissionaryfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionaryfemale1"}
+				{ "particle": "climaxmissionaryfemale1" }
 			]
 		},
 		"climaxstandingmale1": {
 			"anchorPart": "actor1-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingmale1"}
+				{ "particle": "climaxstandingmale1" }
 			]
 		},
 		"climaxstandingfemale1": {
 			"anchorPart": "actor1-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingfemale1"}
+				{ "particle": "climaxstandingfemale1" }
 			]
 		},
 		"actor3-lactation-drip1": {
 			"anchorPart": "actor3-nipple1",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor3-lactation-spew1": {
 			"anchorPart": "actor3-nipple1",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"actor3-lactation-drip2": {
 			"anchorPart": "actor3-nipple2",
 			"burstCount": 1,
 			"particles": [
-				{"particle": "sexbound_lactation1"}
+				{ "particle": "sexbound_lactation1" }
 			]
 		},
 		"actor3-lactation-spew2": {
 			"anchorPart": "actor3-nipple2",
 			"burstCount": 8,
 			"particles": [
-				{"particle": "sexbound_lactation2"}
+				{ "particle": "sexbound_lactation2" }
 			]
 		},
 		"climaxbutterflymale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflymale2"}
+				{ "particle": "climaxbutterflymale2" }
 			]
 		},
 		"climaxbutterflyfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxbutterflyfemale2"}
+				{ "particle": "climaxbutterflyfemale2" }
 			]
 		},
 		"climaxcowgirlmale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlmale2"}
+				{ "particle": "climaxcowgirlmale2" }
 			]
 		},
 		"climaxcowgirlfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxcowgirlfemale2"}
+				{ "particle": "climaxcowgirlfemale2" }
 			]
 		},
 		"climaxdoggymale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggymale2"}
+				{ "particle": "climaxdoggymale2" }
 			]
 		},
 		"climaxdoggyfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxdoggyfemale2"}
+				{ "particle": "climaxdoggyfemale2" }
 			]
 		},
 		"climaxfellatiomale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiomale2"}
+				{ "particle": "climaxfellatiomale2" }
 			]
 		},
 		"climaxfellatiofemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxfellatiofemale2"}
+				{ "particle": "climaxfellatiofemale2" }
 			]
 		},
 		"climaxmissionarymale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionarymale2"}
+				{ "particle": "climaxmissionarymale2" }
 			]
 		},
 		"climaxmissionaryfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxmissionaryfemale2"}
+				{ "particle": "climaxmissionaryfemale2" }
 			]
 		},
 		"climaxstandingmale3": {
 			"anchorPart": "actor3-climax-with-penis",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingmale2"}
+				{ "particle": "climaxstandingmale2" }
 			]
 		},
 		"climaxstandingfemale3": {
 			"anchorPart": "actor3-climax-with-vagina",
 			"burstCount": 10,
 			"particles": [
-				{"particle": "climaxstandingfemale2"}
+				{ "particle": "climaxstandingfemale2" }
 			]
 		}
 	},
 	"sounds": {
-		"actor1moan":	[],
-		"actor2moan":	[],
-		"actor3moan":	[],
-		"actor4moan":	[],
-		"actor1orgasm":	[],
-		"actor2orgasm":	[],
-		"actor3orgasm":	[],
-		"actor4orgasm":	[],
-		"climax":		[]
+		"actor1moan": [ ],
+		"actor2moan": [ ],
+		"actor3moan": [ ],
+		"actor4moan": [ ],
+		"actor1orgasm": [ ],
+		"actor2orgasm": [ ],
+		"actor3orgasm": [ ],
+		"actor4orgasm": [ ],
+		"climax": [ ]
 	},
 	"transformationGroups": {
-		"actors":				{"interpolated": true},
-		"actor2Body":			{"interpolated": true},
-		"actor2Groinwear1":		{"interpolated": true},
-		"actor2Head":			{"interpolated": true},
-		"actor2Nippleswear1":	{"interpolated": true},
-		"actor2Nippleswear2":	{"interpolated": true},
-		"actor1Body":			{"interpolated": true},
-		"actor1Groinwear1":		{"interpolated": true},
-		"actor1Head":			{"interpolated": true},
-		"actor1Nippleswear1":	{"interpolated": true},
-		"actor1Nippleswear2":	{"interpolated": true},
-		"actor3Body":			{"interpolated": true},
-		"actor3Groinwear1":		{"interpolated": true},
-		"actor3Head":			{"interpolated": true},
-		"actor3Nippleswear1":	{"interpolated": true},
-		"actor3Nippleswear2":	{"interpolated": true}
+		"actors": { "interpolated": true },
+		"actor2Body": { "interpolated": true },
+		"actor2Groinwear1": { "interpolated": true },
+		"actor2Head": { "interpolated": true },
+		"actor2Nippleswear1": { "interpolated": true },
+		"actor2Nippleswear2": { "interpolated": true },
+		"actor1Body": { "interpolated": true },
+		"actor1Groinwear1": { "interpolated": true },
+		"actor1Head": { "interpolated": true },
+		"actor1Nippleswear1": { "interpolated": true },
+		"actor1Nippleswear2": { "interpolated": true },
+		"actor3Body": { "interpolated": true },
+		"actor3Groinwear1": { "interpolated": true },
+		"actor3Head": { "interpolated": true },
+		"actor3Nippleswear1": { "interpolated": true },
+		"actor3Nippleswear2": { "interpolated": true }
 	}
 }

--- a/scripts/sexbound/lib/sexbound.lua
+++ b/scripts/sexbound/lib/sexbound.lua
@@ -1020,6 +1020,7 @@ function Sexbound:handleSyncUI(args)
             species         = actor:getSpecies(),
             status          = {
                 isPregnant  = actor:isVisiblyPregnant(),
+                isSwollen = actor:isBellySwollen(),
                 isClimaxing = actor._isClimaxing or false,
                 isPreClimaxing = actor._isPreClimaxing or false,
                 isScriptedClimaxing = actor._isScriptedClimaxing or false

--- a/scripts/sexbound/lib/sexbound/actor.lua
+++ b/scripts/sexbound/lib/sexbound/actor.lua
@@ -310,7 +310,7 @@ function Sexbound.Actor:loadGroin(entityGroup, role, species, gender)
 
     local subGender = self:getSubGender()
 
-    if self:isVisiblyPregnant() and self:isEnabledPregnancyFetish() then
+    if self:isBellySwollen() and self:isEnabledPregnancyFetish() then
         if self:getGenitalType() == "male" then
             image = self:getSprite(animState, "groinGenitalPregnancy", {
                 entityGroup = entityGroup,
@@ -1271,6 +1271,14 @@ function Sexbound.Actor:isPregnant()
     end
 
     return plugin:isPregnant()
+end
+
+function Sexbound.Actor:isBellySwollen()
+    local plugin = self:getPlugins("pregnant")
+
+    if plugin == nil then return false end
+
+    return plugin:isBellySwollen()
 end
 
 function Sexbound.Actor:isVisiblyPregnant()

--- a/scripts/sexbound/plugins/pregnant/pregnant.lua
+++ b/scripts/sexbound/plugins/pregnant/pregnant.lua
@@ -308,7 +308,8 @@ end
 
 --- Returns whether or not the actor has a swollen belly
 function Sexbound.Actor.Pregnant:isBellySwollen()
-    return self:getCurrentAllInseminations() >= self:getSwellingThreshold() or self:isVisiblyPregnant()
+    return self._config.enableInflationFetish and self:getCurrentAllInseminations() >= self:getSwellingThreshold()
+        or self:isVisiblyPregnant()
 end
 
 --- Returns whether or not the actor is visibly pregnant
@@ -952,6 +953,7 @@ function Sexbound.Actor.Pregnant:validateConfig()
     self:validateEnableMultipleImpregnations(self._config.enableMultipleImpregnations)
     --self:validateEnableNotifyPlayers(self._config.enableNotifyPlayers)
     self:validateEnablePregnancyFetish(self._config.enablePregnancyFetish)
+    self:validateEnableInflationFetish(self._config.enableInflationFetish)
     --self:validateEnableSilentImpregnations(self._config.enableSilentImpregnations)
     self:validateFertility(self._config.fertility)
     self:validateFertilityBonusMult(self._config.fertilityBonusMult)
@@ -1042,6 +1044,16 @@ function Sexbound.Actor.Pregnant:validateEnablePregnancyFetish(value)
         return
     end
     self._config.enablePregnancyFetish = value
+end
+
+--- Ensures enableInflationFetish is set to an allowed value
+-- @param value
+function Sexbound.Actor.Pregnant:validateEnableInflationFetish(value)
+    if type(value) ~= "boolean" then
+        self._config.enableInflationFetish = true
+        return
+    end
+    self._config.enableInflationFetish = value
 end
 
 --- Ensures enableSilentImpregnations is set to an allowed value

--- a/scripts/sexbound/plugins/pregnant/pregnant.lua
+++ b/scripts/sexbound/plugins/pregnant/pregnant.lua
@@ -233,6 +233,12 @@ end
 function Sexbound.Actor.Pregnant:isPregnant()
     return self:getCurrentPregnancyCount() > 0
 end
+
+--- Returns whether or not the actor has a swollen belly
+function Sexbound.Actor.Pregnant:isBellySwollen()
+    return self:getCurrentAllInseminations() >= 7.5 or self:isVisiblyPregnant()
+end
+
 --- Returns whether or not the actor is visibly pregnant
 function Sexbound.Actor.Pregnant:isVisiblyPregnant()
     return self:getCurrentVisiblePregnancyCount() > 0
@@ -352,7 +358,6 @@ function Sexbound.Actor.Pregnant:thisActorHasEnoughFertility(otherActor)
     end
 
     local pregnancyChance = self:generateRandomNumber() / 100;
-    self:getLog():debug("Fertility roll: "..pregnancyChance.." <= "..fertility)
     self:getLog():info("Pregnancy roll : " .. pregnancyChance .. " <= " .. fertility)
     return pregnancyChance <= fertility
 end
@@ -766,6 +771,15 @@ function Sexbound.Actor.Pregnant:getCurrentInseminations(otherActor)
     local inseminations = self._insemins
     local otherUuid = otherActor._config.uniqueId or "other"
     return inseminations[otherUuid] or 0
+end
+
+function Sexbound.Actor.Pregnant:getCurrentAllInseminations()
+    local inseminations = self._insemins
+    local count = 0
+    for k, v in pairs(inseminations) do
+        count = count + v
+    end
+    return count
 end
 
 --- Returns a reference to this actor's current pregnancies table

--- a/sxb_plugin.pregnant.config
+++ b/sxb_plugin.pregnant.config
@@ -179,6 +179,21 @@
   "fertilityMult": 1.15,
 
   /**
+   * This number range determines how quickly an actor's insemination counter decays when dripping (Default: [ 0.2, 0,3 ])
+   */
+  "inseminationDecay": [ 0.2, 0.3 ],
+
+  /**
+   * Affects the pace of dripping and insemination decay (Default: 1.5)
+   */
+  "dripRateModifier": 1.5,
+
+  /**
+   * Affects the amount of repeated inseminations required to start showing swollen abdomen (Default: 7.5)
+   */
+  "swellingThreshold": 7.5,
+
+  /**
    * There are three trimesters in a pregnancy, but you can set it to be more or less than 3.
    *
    * Note: This number is multiplied by the trimesterLength.

--- a/sxb_plugin.pregnant.config
+++ b/sxb_plugin.pregnant.config
@@ -60,20 +60,20 @@
    * "all" is available as a universal placeholder
    */
   "compatibleSpecies": {
-    "apex": [],
-    "avian": [],
-    "fenerox": [],
-    "floran": [],
-    "glitch": [],
-    "human": [],
-    "hylotl": [],
-    "novakid": [],
-    "penguin": [],
-    "neki": [],
-    "neko": [],
-    "felin": []
+    "apex": [ ],
+    "avian": [ ],
+    "fenerox": [ ],
+    "floran": [ ],
+    "glitch": [ ],
+    "human": [ ],
+    "hylotl": [ ],
+    "novakid": [ ],
+    "penguin": [ ],
+    "neki": [ ],
+    "neko": [ ],
+    "felin": [ ]
   },
-  
+
   /**
    * A table defining species which, when crossed, result in a specified third species baby
    *
@@ -82,33 +82,33 @@
    * "motherSpecies": {"fatherSpecies": "childSpecies"}
    */
   "geneticTable": {
-    
+
   },
-  
+
   /**
    * true  := Certain races and conditions can abort pregnancies during climax
    * false := Disables pregnancy hazards during climax
    */
   "enablePregnancyHazards": true,
-  
+
   /**
    * List of pregnancy hazard probabilities (if enabled)
    * "Climaxing Species": {"Fucked Species": Probability}
    * Same species sex is always safe
    */
   "pregnancyHazards": {
-    "default": {"default": 0.0},
-    "novakid": {"default": 0.1, "avali": 0.2, "floran": 0.2},
-    "avali": {"default": 0.1},
-    "glitch": {"default": 0.05},
-    "floran": {"default": 0.05}
+    "default": { "default": 0.0 },
+    "novakid": { "default": 0.1, "avali": 0.2, "floran": 0.2 },
+    "avali": { "default": 0.1 },
+    "glitch": { "default": 0.05 },
+    "floran": { "default": 0.05 }
   },
-  
+
   /**
    * Chance for birth to fail
    */
   "stillbornChance": 0.005,
-  
+
   /**
    * List of species who are immune to pregnancy hazards
    */
@@ -121,14 +121,14 @@
    * OBSOLETE - MOVED TO MAIN CONFIG
    * Only kept to not break older patches
    */
-  "whichGendersCanProduceSperm": ["futanari", "male"],
+  "whichGendersCanProduceSperm": [ "futanari", "male" ],
 
   /**
    * A list of genders that can ovulate or can be made pregnant.
    * OBSOLETE - MOVED TO MAIN CONFIG.
    * Only kept to not break older patches
    */
-  "whichGendersCanOvulate": ["female", "futanari", "cuntboy"],
+  "whichGendersCanOvulate": [ "female", "futanari", "cuntboy" ],
 
   /**
    * A list of status names to check on the impregnated actor to prevent a pregnancy.
@@ -153,15 +153,25 @@
   "useOSTimeForPregnancies": false,
 
   /**
-   * Affects the chance to become pregnant for players (Default: 0.5 = 50% chance)
+   * Affects the chance to become pregnant for players (Default: 0.3 = 30% chance)
    * When period cycle is enabled, only affects the chance to become pregnant during ovulation period, so a higher chance might be better
    */
-  "fertility": 0.5,
-  
+  "fertility": 0.3,
+
   /**
    * Affects the chance to become pregnant for non-player entities (NPCs, monster) (Default: 0.1 = 10% chance)
    */
   "fertilityNPC": 0.1,
+
+  /**
+   * Specifies the repeated insemination pregnancy chance bonus multiplier (Default: 1.08 -> 8%, 17%, 26%, 36%, 47%, 59%, 71%, ...)
+   */
+  "fertilityBonusMult": 1.08,
+
+  /**
+   * Specifies the maximum chance to become pregnant after applying repeated insemination bonus (Default: 0.6 = 60% chance)
+   */
+  "fertilityBonusMax": 0.6,
 
   /**
    * Fertility pill chance multiplier. An entity's fertility chance gets multiplied with this value.
@@ -179,29 +189,29 @@
    * Each trimester lasts 2 - 3 days.
    */
   "trimesterLength": [2, 3],
-  
+
   /**
    * true  := Use realistic period cycle, meaning pregnancy can only occur during ovulation period like in real life (player only)
    * false := Use simplistic model where every climax has a fertility roll
    */
   "enablePeriodCycle": true,
-  
+
   /**
    * The time between each ovulation day as [min, max] number of days (based on average 840 second ingame day)
    */
-  "periodCycleLength": [3, 5],
-  
+  "periodCycleLength": [ 3, 5 ],
+
   /**
    * Chance for any impregnation to create multiple babies (twins, triplets, ...)
    * This value (as percentage, 0.01 = 1%) determines the chance for a generated baby to generate another. Meaning 1% for twins, 0.01% for triplets, ...
    */
   "multiPregnancyChance": 0.01,
-  
+
   /**
    * Count limit of multi pregnancies. 3 = maximum of triplets, 2 = maximum of twins, ...
    */
   "multiPregnancyLimit": 3,
-  
+
   /**
    * If you want pregnancy tests to be infinitely reusable like in the past, set this to true
    */

--- a/sxb_plugin.pregnant.config
+++ b/sxb_plugin.pregnant.config
@@ -38,6 +38,12 @@
   "enablePregnancyFetish": true,
 
   /**
+   * true  := Show swollen tummies of actors after repeated inseminations during sex interaction.
+   * false := Do not show swollen tummies of actors after repeated inseminations during sex interaction.
+   */
+  "enableInflationFetish": true,
+
+  /**
    * OBSOLETE - REPLACED BY MAIN CONFIG "immersionLevel"
    * true  := Suppress all notifications and radio messages about impregnations.
    * false := disabled.


### PR DESCRIPTION
New features:
- pregnancy roll bonus on repeated internal shots
- switch to pregnant sprites after repeated internal shots
- dripping in non-penetrative states

Also changed default fertility to 30% to facilitate the use of the new bonus.