### PR TITLE
Extra data for PoV

### DIFF
--- a/scripts/sexbound/lib/sexbound/actor.lua
+++ b/scripts/sexbound/lib/sexbound/actor.lua
@@ -1394,8 +1394,8 @@ function Sexbound.Actor:getUIData(args)
         bodyType        = self:getBodyType(),
         hairID          = self:getIdentity("hairType"),              -- Data used by PoV for hairs/facial details.
         hairDirectives  = self:getIdentity("hairDirectives"),
-        facialType      = self:getIdentity("facialMaskType") or "",
-        facialID        = self:getIdentity("facialMask") or "",
+        facialType      = self:getIdentity("facialMaskGroup") or "",
+        facialID        = self:getIdentity("facialMaskType") or "",
         showBackwear    = self:getApparel():getIsVisible("backwear"),
         showChestwear   = self:getApparel():getIsVisible("chestwear"),
         showHeadwear    = self:getApparel():getIsVisible("headwear"),

--- a/scripts/sexbound/lib/sexbound/actor.lua
+++ b/scripts/sexbound/lib/sexbound/actor.lua
@@ -1392,8 +1392,10 @@ function Sexbound.Actor:getUIData(args)
         actorSlot       = "actor" .. self:getActorNumber(),
         bodyDirectives  = self:getIdentity("bodyDirectives"),
         bodyType        = self:getBodyType(),
-        hairID          = self:getIdentity("hairType"),
+        hairID          = self:getIdentity("hairType"),              -- Data used by PoV for hairs/facial details.
         hairDirectives  = self:getIdentity("hairDirectives"),
+        facialType      = self:getIdentity("facialMaskType") or "",
+        facialID        = self:getIdentity("facialMask") or "",
         showBackwear    = self:getApparel():getIsVisible("backwear"),
         showChestwear   = self:getApparel():getIsVisible("chestwear"),
         showHeadwear    = self:getApparel():getIsVisible("headwear"),


### PR DESCRIPTION
Adds two more entries in actor data for facial mask type and ID, required for future PoV supports for races with beaks/brands and more.