### PR TITLE
Quickfixes

### DIFF
--- a/scripts/sexbound/lib/sexbound/actor.lua
+++ b/scripts/sexbound/lib/sexbound/actor.lua
@@ -1554,8 +1554,8 @@ function Sexbound.Actor:getUIData(args)
         bodyType        = self:getBodyType(),
         hairID          = self:getIdentity("hairType"),              -- Data used by PoV for hairs/facial details.
         hairDirectives  = self:getIdentity("hairDirectives"),
-        facialType      = self:getIdentity("facialMaskGroup") or "",
-        facialID        = self:getIdentity("facialMaskType") or "",
+        facialType      = self:getIdentity("facialHairGroup") or "",
+        facialID        = self:getIdentity("facialHairType") or "",
         showBackwear    = self:getApparel():getIsVisible("backwear"),
         showChestwear   = self:getApparel():getIsVisible("chestwear"),
         showHeadwear    = self:getApparel():getIsVisible("headwear"),

--- a/scripts/sexbound/override/common/subgender.lua
+++ b/scripts/sexbound/override/common/subgender.lua
@@ -178,7 +178,7 @@ end
 function Sexbound.Common.SubGender:createRandomSubGender(gender)
     local possibleSubGenders = {}
     local count = 0
-    for _,g in ipairs(self:getAllSubGenders) do
+    for _,g in ipairs(self:getAllSubGenders()) do
         if g.available then table.insert(possibleSubGenders, g.name) count = count + 1 end
     end
     


### PR DESCRIPTION
Adds a missing () in "getAllSubGenders" for common/subgender.
Properly names and lists the "FACIAL HAIR" instead of "FACIAL MASK". I thought this was the one used for Novakid brands and Avian Fluffs, I was incorrect! Next time you see a Novakid's brand, remind yourself, it is made of "Sun beard".