### PR TITLE
Spawn semen when dripping

### DIFF
--- a/scripts/sexbound/plugins/climax/climax.lua
+++ b/scripts/sexbound/plugins/climax/climax.lua
@@ -508,7 +508,16 @@ function Sexbound.Actor.Climax:inflationDrip(dt)
         local oldAmount = self._inflation
         if oldAmount > 0 then
             local actor = self._parent
-            self._inflation = math.max(0, self._inflation - util.randomInRange(self:getDripRate()) * dt)
+
+            local dripQuantity = math.min(util.randomInRange(self:getDripRate()) * dt, self._inflation)
+            self._inflation = self._inflation - dripQuantity
+
+            if self._config.enableSpawnLiquids then
+                local spawnPosition = actor:getClimaxSpawnPosition() or {0.0, 0.0}
+                local semenId = 157
+                world.spawnLiquid(spawnPosition, semenId, dripQuantity)
+            end
+
             self:getLog():debug("Actor "..actor:getActorNumber().." dripping. New amount: "..self._inflation)
             if oldAmount >= self:getInflationThreshold() and self._inflation < self:getInflationThreshold() then
                 actor:resetParts(actor:getAnimationState(), actor:getSpecies(), actor:getGender(), actor:resetDirectives(actor:getActorNumber()))


### PR DESCRIPTION
A small tweak I made for myself, but I thought I'd share here.
Made the dripping mechanic spawn liquid semen if spawning liquid is enabled in the configs.

Feel free to close without merging if the feature isn't wanted.
Otherwise, let me know if I should tweak anything before it's merged.