### PR TITLE
Fix climax projectile liquid physics interactions

### DIFF
--- a/projectiles/physics.config.patch
+++ b/projectiles/physics.config.patch
@@ -18,7 +18,7 @@
       "ignorePlatformCollision": true,
 
       "airFriction": 0.0,
-      "liquidFriction": 50.0,
+      "liquidFriction": 0.0,
       "groundFriction": 20.0,
       "maximumCorrection": 0.75
     }


### PR DESCRIPTION
Removed liquid friction from climax projectile's physics config.
This fixes climax projectiles getting stuck on liquid and dying without triggering their "liquid" action.