### PR TITLE
Fix typo in sxb_plugin.lactate.config

### DIFF
--- a/sxb_plugin.lactate.config
+++ b/sxb_plugin.lactate.config
@@ -9,7 +9,7 @@
    * What species names to exclude from ability to lactate?
    * Expected value as: an array of strings of species names
    */
-  "excludedSpecies": [ "pengiun" ],
+  "excludedSpecies": [ "penguin" ],
 
   /**
    * When is the next burst time or time to lactate drops of milk?


### PR DESCRIPTION
Kinda blursed that Novakid isn't in the list, but I digress. =P Penguins absolutely don't lactate, but I don't believe "pengiun" is the correct exclusion. =P