### PR TITLE
infinite money glitch fix

### DIFF
--- a/items/active/sexbound_sexbox/sexbound_sexboxplus.activeitem
+++ b/items/active/sexbound_sexbox/sexbound_sexboxplus.activeitem
@@ -1,6 +1,6 @@
 {
   "itemName" : "sexbound_sexboxplus",
-  "price" : 10000,
+  "price" : 5000,
   "level" : 1,
   "maxStack" : 1000,
   "rarity" : "Essential",


### PR DESCRIPTION
having a normal sexbox as 1000 and a plus one as 10000 creates a money exploit where you could upgrade a normal 1000 one to a 10000 one for free, which you can sell for 10000 * 20% = 2000 pixels, which creates an infinite money exploit