### PR TITLE
Add status effects to force enable ovulation and sperm production

### DIFF
--- a/scripts/sexbound/lib/sexbound/actor.lua
+++ b/scripts/sexbound/lib/sexbound/actor.lua
@@ -643,6 +643,8 @@ function Sexbound.Actor:setup(actorConfig)
     if self._config.inHeat then actorStatus:addStatus("sexbound_aroused_heat") end
     if self._config.isDefeated then actorStatus:addStatus("sexbound_defeated") end
     if self._config.birthcontrol then actorStatus:addStatus("birthcontrol") end
+    if self._config.forceCanOvulate then actorStatus:addStatus("sexbound_override_can_ovulate") end
+    if self._config.forceCanProduceSperm then actorStatus:addStatus("sexbound_override_can_produce_sperm") end
     
     if self._config.identity.sxbNaturalStatus then
         for _,s in ipairs(self._config.identity.sxbNaturalStatus) do
@@ -650,7 +652,7 @@ function Sexbound.Actor:setup(actorConfig)
         end
     end
     
-    self:getLog():debug("Actor "..self:getName().." setup fertility: fertile "..tostring(self._config.isFertile).." - hyperFertile "..tostring(self._config.isHyperFertile).." - ovulating "..tostring(self._config.isOvulating).." - defeated "..tostring(self._config.isDefeated).." - birthcontrol "..tostring(self._config.birthcontrol))
+    self:getLog():debug("Actor "..self:getName().." setup fertility: fertile "..tostring(self._config.isFertile).." - hyperFertile "..tostring(self._config.isHyperFertile).." - ovulating "..tostring(self._config.isOvulating).." - defeated "..tostring(self._config.isDefeated).." - birthcontrol "..tostring(self._config.birthcontrol).." - can ovulate override "..tostring(self._config.forceCanOvulate).." - produce sperm override "..tostring(self._config.forceCanProduceSperm))
     
     self:initPlugins()
     self:getApparel():sync() -- initial fetching of apparel to determine initial gender
@@ -1499,11 +1501,11 @@ end
 
 --- Returns if this actor is capable of ovulating
 function Sexbound.Actor:canOvulate()
-    return self:getIdentity().body.canOvulate or false
+    return self:getIdentity().body.canOvulate or self:getStatus():hasStatus("sexbound_override_can_ovulate") or false
 end
 --- Returns if this actor is capable of producing sperm
 function Sexbound.Actor:canProduceSperm()
-    return self:getIdentity().body.canProduceSperm or false
+    return self:getIdentity().body.canProduceSperm or self:getStatus():hasStatus("sexbound_override_can_produce_sperm") or false
 end
 --- Returns if this actor has means to penetrate another actor
 function Sexbound.Actor:canPenetrate()

--- a/scripts/sexbound/override/common.lua
+++ b/scripts/sexbound/override/common.lua
@@ -130,7 +130,7 @@ function Sexbound.Common:buildBodyTraits(gender)
 end
 
 function Sexbound.Common:updateTraitEffects()
-    if (self._pregnant and self._pregnant._config.enableFreeForAll) and not self._bodyTraits.canOvulate then
+    if (self._pregnant and self._pregnant._config.enableFreeForAll) and not (self._bodyTraits.canOvulate or status.statusProperty("sexbound_override_can_ovulate", false)) then
         storage.sexbound.pregnant = {} -- If we cannot ovulate anymore, remove current pregnancies
         storage.sexbound.ovulationCycle = 0 -- If we cannot ovulate anymore, remove and reset ovulation cycle
         status.removeEphemeralEffect("sexbound_custom_ovulating")

--- a/scripts/sexbound/override/common.lua
+++ b/scripts/sexbound/override/common.lua
@@ -130,7 +130,7 @@ function Sexbound.Common:buildBodyTraits(gender)
 end
 
 function Sexbound.Common:updateTraitEffects()
-    if (self._pregnant and self._pregnant._config.enableFreeForAll) and not (self._bodyTraits.canOvulate or status.statusProperty("sexbound_override_can_ovulate", false)) then
+    if (self._pregnant and not self._pregnant._config.enableFreeForAll) and not (self._bodyTraits.canOvulate or status.statusProperty("sexbound_override_can_ovulate", false)) then
         storage.sexbound.pregnant = {} -- If we cannot ovulate anymore, remove current pregnancies
         storage.sexbound.ovulationCycle = 0 -- If we cannot ovulate anymore, remove and reset ovulation cycle
         status.removeEphemeralEffect("sexbound_custom_ovulating")

--- a/scripts/sexbound/override/player.lua
+++ b/scripts/sexbound/override/player.lua
@@ -520,6 +520,8 @@ function Sexbound.Player:getActorData()
         isFertile = status.statusProperty("sexbound_custom_fertility", false),
         isHyperFertile = status.statusProperty("sexbound_custom_hyper_fertility", false),
         isOvulating = status.statusProperty("sexbound_custom_ovulating", false),
+        forceCanOvulate = status.statusProperty("sexbound_override_can_ovulate", false),
+        forceCanProduceSperm = status.statusProperty("sexbound_override_can_produce_sperm", false),
         birthcontrol = status.statusProperty("sexbound_birthcontrol"),
         aroused = status.statusProperty("sexbound_aroused", false),
         arousedStrong = status.statusProperty("sexbound_aroused_strong", false),

--- a/scripts/sexbound/override/player/pregnant.lua
+++ b/scripts/sexbound/override/player/pregnant.lua
@@ -131,6 +131,8 @@ function Sexbound.Player.Pregnant:canOvulate()
 
     if self:getParent()._bodyTraits.canOvulate or false then return true end
 
+	if status.statusProperty("sexbound_override_can_ovulate", false) then return true end
+
     return false
 end
 

--- a/stats/effects/sexbound_override_can_ovulate/sexbound_override_can_ovulate.lua
+++ b/stats/effects/sexbound_override_can_ovulate/sexbound_override_can_ovulate.lua
@@ -1,0 +1,11 @@
+function init()
+  local entityId = entity.id()
+  status.setStatusProperty("sexbound_override_can_ovulate", true)
+  world.sendEntityMessage(entityId, "Sexbound:Pregnant:AddStatus", "sexbound_override_can_ovulate")
+end
+
+function uninit()
+  local entityId = entity.id()
+  status.setStatusProperty("sexbound_override_can_ovulate", false)
+  world.sendEntityMessage(entityId, "Sexbound:Pregnant:RemoveStatus", "sexbound_override_can_ovulate")
+end

--- a/stats/effects/sexbound_override_can_ovulate/sexbound_override_can_ovulate.statuseffect
+++ b/stats/effects/sexbound_override_can_ovulate/sexbound_override_can_ovulate.statuseffect
@@ -1,0 +1,7 @@
+{
+  "name"            : "sexbound_override_can_ovulate",
+  "blockingStat"    : "sexboundImmunity",
+  "defaultDuration" : 10,
+  "effectConfig"    : {},
+  "scripts"         : [ "sexbound_override_can_ovulate.lua" ]
+}

--- a/stats/effects/sexbound_override_can_produce_sperm/sexbound_override_can_produce_sperm.lua
+++ b/stats/effects/sexbound_override_can_produce_sperm/sexbound_override_can_produce_sperm.lua
@@ -1,0 +1,11 @@
+function init()
+  local entityId = entity.id()
+  status.setStatusProperty("sexbound_override_can_produce_sperm", true)
+  world.sendEntityMessage(entityId, "Sexbound:Pregnant:AddStatus", "sexbound_override_can_produce_sperm")
+end
+
+function uninit()
+  local entityId = entity.id()
+  status.setStatusProperty("sexbound_override_can_produce_sperm", false)
+  world.sendEntityMessage(entityId, "Sexbound:Pregnant:RemoveStatus", "sexbound_override_can_produce_sperm")
+end

--- a/stats/effects/sexbound_override_can_produce_sperm/sexbound_override_can_produce_sperm.statuseffect
+++ b/stats/effects/sexbound_override_can_produce_sperm/sexbound_override_can_produce_sperm.statuseffect
@@ -1,0 +1,7 @@
+{
+  "name"            : "sexbound_override_can_produce_sperm",
+  "blockingStat"    : "sexboundImmunity",
+  "defaultDuration" : 10,
+  "effectConfig"    : {},
+  "scripts"         : [ "sexbound_override_can_produce_sperm.lua" ]
+}


### PR DESCRIPTION
There are already plenty of status effects that allow for preventing ovulation / sperm production, but none that allow for them to be enabled (short of changing subgender).

This pull request adds two invisible status effects that will enable ovulation (`sexbound_override_can_ovulate`) and sperm production (`sexbound_override_can_produce_sperm`) for an actor without changing their subgender. Specifically, for addon use.

These status effects are blocked by all the normal stuff, and won't take precedence over any statuses that would normally block ovulation/sperm production (in effect, it would be as if that actor's gender allowed ovulation / sperm production in the config).